### PR TITLE
api gateway to sqs and sns integration

### DIFF
--- a/src/constructs/topic.ts
+++ b/src/constructs/topic.ts
@@ -46,6 +46,7 @@ export class TopicConstruct implements FW24Construct {
             });
             this.fw24.setConstructOutput(this, topicConfig.topicName, topic, OutputType.TOPIC);
             this.fw24.set(topicConfig.topicName, topic.topicName, "topicName");
+            this.fw24.set(topicConfig.topicName, topic, "topic");
 
             if(topicConfig.notificationProps?.email){
                 for (const email of topicConfig.notificationProps.email) {

--- a/src/core/fw24.ts
+++ b/src/core/fw24.ts
@@ -202,7 +202,7 @@ export class Fw24 {
                 continue;
             }
             // get role
-            this.logger.info("addRouteToRolePolicy:", {route, groupName});
+            this.logger.debug("addRouteToRolePolicy:", {route, groupName});
             const role: Role = this.get('Role', 'cognito_' + groupName);
             if(!role) {
                 this.logger.error(`Role not found for group: ${groupName}. Role is required to add route: ${route} to role policy. Please make sure you have a group defined in your config with the name: ${groupName}.`);

--- a/src/core/helper.ts
+++ b/src/core/helper.ts
@@ -104,7 +104,7 @@ export class Helper {
 
         // Register the handlers
         for (const handlerPath of handlerPaths) {
-            Helper.logger.info("Registering Lambda Handlers from handlerPath: "+ handlerPath);
+            Helper.logger.debug("Registering Lambda Handlers from handlerPath: "+ handlerPath);
             try {
                 // Dynamically import the controller file
                 const module = await import(join(handlerDirectory, handlerPath));
@@ -118,12 +118,12 @@ export class Helper {
                             filePath: handlerDirectory,
                         };
 
-                        Helper.logger.info("Registering Lambda Handlers registering currentHandler: ", {handlerPath, handlerDirectory});
+                        Helper.logger.debug("Registering Lambda Handlers registering currentHandler: ", {handlerPath, handlerDirectory});
 
                         handlerRegistrar(currentHandler);
                         break;
                     } else {
-                        Helper.logger.info("Registering Lambda Handlers ignored exportedItem: ", {exportedItem});
+                        Helper.logger.debug("Registering Lambda Handlers ignored exportedItem: ", {exportedItem});
                     }
                 }
             } catch (err) {

--- a/src/decorators/controller.ts
+++ b/src/decorators/controller.ts
@@ -48,6 +48,13 @@ export interface IControllerConfig {
 	 * Specifies the removal policy for the controller function's logs.
 	 */
 	logRemovalPolicy?: RemovalPolicy;
+
+	/**
+     * Specifies the target for the API
+     * Values can be "function", "queue" or "topic"
+     * @default "function"
+     */
+    target?: string;
 }
 
 /**

--- a/src/decorators/method.ts
+++ b/src/decorators/method.ts
@@ -28,7 +28,13 @@ function createRouteDecorator(method: string) {
   return (
     route: string,
     options ?: {
-      validations?: InputValidationRule | HttpRequestValidations
+      validations?: InputValidationRule | HttpRequestValidations,
+      /**
+       * Specifies the target for the API
+       * Values can be "queue" or "topic"
+       * @default ""
+       */
+      target?: string;
     } 
   ) =>
     (target: any, methodToDecorate: any) => {
@@ -61,6 +67,7 @@ function createRouteDecorator(method: string) {
         functionName: methodToDecorate.name || methodToDecorate,
         parameters: parameters,
         validations: options?.validations,
+        target: options?.target
       };
 
       Reflect.set(target, "routes", routes);

--- a/src/interfaces/route.ts
+++ b/src/interfaces/route.ts
@@ -10,7 +10,8 @@ export interface Route {
 		type?: string;
     groups?: string[];
 	} | string;
-  validations ?: InputValidationRule | HttpRequestValidations
+  validations ?: InputValidationRule | HttpRequestValidations;
+  target?: string;
 }
 
 export type Routes = Route[];


### PR DESCRIPTION
Ability to use SQS and SNS directly through API gateway without lambda. 
[Add ability to create async webhook API](https://github.com/ten24group/fw24-tasks/issues/9)

example use: 
```
@Controller('webhook', {
	authorizer: 'NONE',
	target: ''
})
export class Webhook extends APIController {

	async initialize() {
		// register DI factories
		return Promise.resolve();
	}
	
	// will send message to a existing queue with name "myqueue"
	@Post('/myqueue1', {
		target: 'queue'
	})
	myqueue1(){}

	// will send message to an existing topic with name "mytopic"
	@Post('/mytopic', {
		target: 'topic'
	})
	mytopic(){}

}

```