### PR TITLE
custom domain for s3, api and amplify

### DIFF
--- a/src/constructs/certificate.ts
+++ b/src/constructs/certificate.ts
@@ -1,0 +1,43 @@
+import { Helper } from "../core/helper";
+import { Fw24 } from "../core/fw24";
+import { FW24Construct, FW24ConstructOutput, OutputType } from "../interfaces/construct";
+import { LogDuration, createLogger } from "../logging";
+import { CfnOutput } from "aws-cdk-lib";
+import { Certificate, CertificateValidation, ICertificate } from "aws-cdk-lib/aws-certificatemanager";
+
+/**
+ * Represents the configuration for a certificate construct.
+ */
+export interface ICertificateConstructConfig {
+    domainName: string;
+    certificateArn?: string;
+}
+
+export class CertificateConstruct implements FW24Construct {
+    readonly logger = createLogger(CertificateConstruct.name);
+    readonly fw24: Fw24 = Fw24.getInstance();
+    
+    name: string = CertificateConstruct.name;
+    dependencies: string[] = [];
+    output!: FW24ConstructOutput;
+
+    constructor(private certificateConstructConfig: ICertificateConstructConfig) {
+        Helper.hydrateConfig(certificateConstructConfig,'ACM');
+    }
+
+    public async construct() {
+        const mainStack = this.fw24.getStack('main');
+
+        let certificate: any;
+        if (this.certificateConstructConfig.certificateArn){
+            certificate = Certificate.fromCertificateArn(mainStack, this.fw24.appName + this.certificateConstructConfig.domainName + '-certificate', this.certificateConstructConfig.certificateArn);
+        } else if(!this.certificateConstructConfig.certificateArn){
+            certificate = new Certificate(mainStack, this.fw24.appName + this.certificateConstructConfig.domainName + '-certificate', {
+                domainName: this.certificateConstructConfig.domainName,
+                validation: CertificateValidation.fromDns(),
+            });
+        } 
+        this.fw24.setConstructOutput(this, this.certificateConstructConfig.domainName, certificate, OutputType.CERTIFICATE);
+
+    }
+}   

--- a/src/interfaces/construct.ts
+++ b/src/interfaces/construct.ts
@@ -7,6 +7,8 @@ import { Topic } from "aws-cdk-lib/aws-sns";
 import { Vpc, ISubnet, ISecurityGroup} from "aws-cdk-lib/aws-ec2";
 import { LayerVersion } from "aws-cdk-lib/aws-lambda";
 import { CfnIdentityPool, UserPool, UserPoolClient } from "aws-cdk-lib/aws-cognito";
+import { CloudFrontWebDistribution } from "aws-cdk-lib/aws-cloudfront";
+import { ICertificate } from "aws-cdk-lib/aws-certificatemanager";
 
 export interface FW24Construct {
     name: string;
@@ -36,6 +38,8 @@ export interface FW24ConstructOutput extends Record<string, any>{
     [OutputType.SUBNET]: Record<string,ISubnet>;
     [OutputType.SUBNETS]: Record<string,ISubnet[]>;
     [OutputType.SECURITYGROUP]: Record<string,ISecurityGroup>;
+    [OutputType.CLOUDFRONTWEBDISTRIBUTION]: Record<string,CloudFrontWebDistribution>;
+    [OutputType.CERTIFICATE]: Record<string,ICertificate>;
     [key: string]: any;
 }
 
@@ -55,5 +59,7 @@ export enum OutputType   {
     VPC = 'vpc',
     SUBNET = 'subnet',
     SUBNETS = 'subnets',
-    SECURITYGROUP = 'securitygroup'
+    SECURITYGROUP = 'securitygroup',
+    CLOUDFRONTWEBDISTRIBUTION = 'cloudfrontwebdistribution',
+    CERTIFICATE = 'certificate',
 }


### PR DESCRIPTION
Amplify example:
```
var amplify = new SiteConstruct({
	...
	domain: process.env.DOMAIN,
	subdomain: process.env.SUBDOMAIN,
	mapRootDomain: process.env.MAP_ROOT_DOMAIN === 'true' ? true : false,
        githubBranch: process.env.GITHUB_BRANCH || 'develop',
        ...
})
```
API Gateway:
```
const api = new APIConstruct({
	...
	domainName: process.env.API_DOMAIN,
	certificateArn: process.env.API_DOMAIN_CERTIFICATE,
        ...
});
```
Bucket:
```
const s3 = new BucketConstruct([
		{
			bucketName: BUCKET_NAME,
			...
			cfnDistributionConfig: {
				domainName: process.env.IMAGE_DOMAIN,
				certificateArn: process.env.BUCKET_DOMAIN_CERTIFICATE,
			}
                         ...
		},
	]
);
```