### PR TITLE
fix(site): update buildSpec type and improve handling in SiteConstruct

### DIFF
--- a/src/constructs/site.ts
+++ b/src/constructs/site.ts
@@ -1,12 +1,12 @@
-import { SecretValue, CfnOutput, Stack } from "aws-cdk-lib";
-import { BuildSpec } from "aws-cdk-lib/aws-codebuild";
 import { App, CustomRule, GitHubSourceCodeProvider } from '@aws-cdk/aws-amplify-alpha';
+import { CfnOutput, SecretValue, Stack } from "aws-cdk-lib";
 
+import { BuildSpec } from "aws-cdk-lib/aws-codebuild/lib";
 import { Fw24 } from "../core/fw24";
-import { FW24Construct, FW24ConstructOutput } from "../interfaces/construct";
 import { Helper } from "../core/helper";
-import { createLogger } from "../logging";
+import { FW24Construct, FW24ConstructOutput } from "../interfaces/construct";
 import { IConstructConfig } from "../interfaces/construct-config";
+import { createLogger } from "../logging";
 import { VpcConstruct } from "./vpc";
 
 /**
@@ -41,7 +41,7 @@ export interface ISiteConstructConfig extends IConstructConfig {
     /**
      * The build specification for the site.
      */
-    buildSpec: BuildSpec;
+    buildSpec: BuildSpec | Record<string, any>;
 
     /**
      * The domain for the site.
@@ -89,7 +89,7 @@ export class SiteConstruct implements FW24Construct {
         // create the amplify app
         const amplifyApp = new App(this.mainStack, `${stackPrefix}-amplify`, {
             appName: `${this.siteConstructConfig.appName}`,
-            buildSpec: BuildSpec.fromObject(this.siteConstructConfig.buildSpec),
+            buildSpec: this.siteConstructConfig.buildSpec instanceof BuildSpec ? this.siteConstructConfig.buildSpec : BuildSpec.fromObject(this.siteConstructConfig.buildSpec),
             sourceCodeProvider: new GitHubSourceCodeProvider({
                 owner: this.siteConstructConfig.githubOwner,
                 repository: this.siteConstructConfig.githubRepo,

--- a/src/constructs/site.ts
+++ b/src/constructs/site.ts
@@ -1,7 +1,6 @@
 import { App, CustomRule, GitHubSourceCodeProvider } from '@aws-cdk/aws-amplify-alpha';
 import { CfnOutput, SecretValue, Stack } from "aws-cdk-lib";
-
-import { BuildSpec } from "aws-cdk-lib/aws-codebuild/lib";
+import { BuildSpec } from "aws-cdk-lib/aws-codebuild";
 import { Fw24 } from "../core/fw24";
 import { Helper } from "../core/helper";
 import { FW24Construct, FW24ConstructOutput } from "../interfaces/construct";


### PR DESCRIPTION
- Changed the type of `buildSpec` in `ISiteConstructConfig` to allow for both `BuildSpec` and a generic object.
- Enhanced the instantiation of `buildSpec` in `SiteConstruct` to handle both types appropriately, ensuring better flexibility in configuration.