### PR TITLE
Add FW24 Evolution Roadmap

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,39 @@
+# FW24 Evolution Roadmap
+
+This roadmap outlines the technical evolution of FW24 towards an "Intelligent Framework" that eliminates boilerplate and maximizes security through build-time intelligence.
+
+## 🧠 Core Architecture: The Build-Time DI Explorer
+The cornerstone of FW24's future is shifting dependency resolution and infrastructure discovery from "Runtime-only" to "Build-Time + Runtime."
+
+### 1. Intelligent Build-Time Resolution
+- **Dry-Run Resolution**: During `cdk synth`, FW24 will perform a mocked resolution of the DI container.
+- **Dynamic Resource Discovery**: Automatically identify AWS resources (DynamoDB Tables, S3 Buckets, SQS Queues) referenced by services.
+- **Auto-IAM Provisioning**: Automatically attach the required IAM policies to Lambdas based on the discovered resource requirements.
+
+### 2. Spring-Boot Inspired Configuration
+- **`@ConfigurationProperties(prefix)`**: Bind configuration paths to class properties with type safety.
+- **`@Value(path)`**: Declarative shorthand for property injection.
+- **Build-Time Validation**: Fail the build if required configuration is missing from `.env` or global config.
+- **Env-Var Tree Shaking**: Inject only the environment variables that are actually reachable in a Lambda's dependency graph.
+
+## 🚀 Priority Phases
+
+### Phase 1: Boilerplate Reduction & "Zero-Config"
+- Implement the `BuildTimeDIExplorer`.
+- Introduce `@Value` and `@ConfigurationProperties`.
+- Automate DynamoDB table access discovery.
+- Implement Environment Variable "Tree Shaking."
+
+### Phase 2: High-Fidelity Local Simulator
+- **CDK-Driven Simulation**: Parse `cdk.out` to spin up a local environment that perfectly matches the deployment plan.
+- **JS-Based Mocks**: Fast, lightweight local mocks for AWS services.
+- **Unified CLI**: `fw24 dev` to start the entire distributed monolith locally.
+
+### Phase 3: Optimized Distribution
+- **Deployment Units**: Group/Split logical modules into physical Lambdas without code changes.
+- **Tree-Shaken Bundling**: Prune unreachable code from the DI graph during the build process.
+
+## 🛡️ Philosophy
+- **Monolith DX, Micro-service Runtime**: Clean code, complex deployment handled by the framework.
+- **Convention over Configuration**: Smart assumptions that can be refined with decorators.
+- **Least-Privilege by Design**: Secure infrastructure is a byproduct of the dependency graph.

--- a/docs/design/intelligent-boilerplate-reduction.md
+++ b/docs/design/intelligent-boilerplate-reduction.md
@@ -1,0 +1,110 @@
+# Design Document: Intelligent Boilerplate Reduction in FW24
+
+## 1. Overview
+FW24 currently requires developers to manually wire infrastructure resources (DynamoDB tables, S3 buckets, etc.) to the Lambda functions that use them. This involves:
+1. Registering the resource with `Fw24` (build-time).
+2. Listing the resource in the `@Controller` or `LambdaFunction` `resourceAccess` property (build-time).
+3. Injecting the resource name/ARN into the Service/Controller via DI (runtime).
+
+This document proposes an **Intelligent Discovery Engine** that leverages the metadata-driven DI system to automatically discover these dependencies and perform the necessary wiring (IAM grants and environment variable injection) without manual configuration.
+
+## 2. Core Concepts
+
+### 2.1 Infrastructure-Aware DI
+CDK constructs (like `TableV2`, `Bucket`, `Queue`) will be registered in the `DIContainer.ROOT` during CDK synthesis as special `infra` providers.
+
+### 2.2 Build-Time DI Explorer
+A new utility will "trace" the dependency graph of a Lambda's entry point (Controller or Handler) during `cdk synth`. It will recursively inspect the class metadata to find all injected dependencies.
+
+### 2.3 Automatic IAM & Environment Injection
+If a dependency resolves to an `infra` provider, the `LambdaFunction` construct will automatically:
+1. Call the appropriate `grant*` method on the CDK resource.
+2. Inject the resource's physical identifier (name or ARN) into the Lambda's environment variables.
+
+## 3. Detailed Design
+
+### 3.1 Marking Infra Providers
+We will extend `ProviderOptions` to include an `isInfra` flag and an `infraResource` reference.
+
+```typescript
+export interface ProviderOptions<T = any> {
+    provide: Token;
+    useValue?: T;
+    // ...
+    isInfra?: boolean;
+    infraResource?: any; // The CDK Construct instance
+}
+```
+
+### 3.2 Construct Registration
+Framework constructs (e.g., `DynamoDBConstruct`) will automatically register their physical resources in the `ROOT` container.
+
+```typescript
+// src/constructs/dynamodb.ts
+const table = new TableV2(this, ...);
+DIContainer.ROOT.register({
+    provide: 'UserTable',
+    useValue: table,
+    type: 'infra',
+    isInfra: true
+});
+```
+
+### 3.3 The Dependency Tracer
+A recursive function that traverses the metadata collected by `@Inject()` and `@Injectable()`.
+
+```typescript
+class DIExplorer {
+    static traceInfraDependencies(target: ClassConstructor): InfraDependency[] {
+        // 1. Get constructor and property deps from MetadataManager
+        // 2. Resolve them in DIContainer.ROOT
+        // 3. If resolved provider.isInfra, add to list
+        // 4. Recursively trace dependencies of non-infra providers
+    }
+}
+```
+
+### 3.4 Lambda Integration
+`LambdaFunction` will call the tracer and apply the findings.
+
+```typescript
+// src/constructs/lambda-function.ts
+const deps = DIExplorer.traceInfraDependencies(props.handlerClass);
+deps.forEach(dep => {
+    if (dep.resource instanceof TableV2) {
+        dep.resource.grantReadWriteData(fn);
+        fn.addEnvironment(dep.token, dep.resource.tableName);
+    }
+    // ... other resource types
+});
+```
+
+## 4. Spring-Inspired Enhancements
+
+### 4.1 `@Value` Decorator
+Allows injecting configuration properties directly into services with build-time validation.
+
+```typescript
+class MyService {
+    @Value('app.payments.apiKey')
+    private apiKey: string;
+}
+```
+
+### 4.2 `@ConfigurationProperties`
+Binds a configuration prefix to a class.
+
+```typescript
+@ConfigurationProperties('app.payments')
+class PaymentConfig {
+    apiKey: string;
+    endpoint: string;
+}
+```
+
+## 5. Implementation Plan
+1. Update `DIContainer` and `MetadataManager` to support `infra` providers.
+2. Modify `DynamoDBConstruct` (and others) to auto-register resources.
+3. Implement `DIExplorer` utility.
+4. Integrate `DIExplorer` into `LambdaFunction`.
+5. Implement `@Value` and `@ConfigurationProperties` decorators.

--- a/docs/design/spring-inspired-config.md
+++ b/docs/design/spring-inspired-config.md
@@ -1,0 +1,83 @@
+# Design Document: Spring-Inspired Configuration in FW24
+
+## 1. Overview
+FW24 currently uses a manual `resolveConfig` or `resolveEnvValueFor` approach to access configuration. While flexible, it lacks type safety at the property level and requires repetitive code.
+
+Inspired by Spring Boot, this design introduces `@Value` and `@ConfigurationProperties` to make configuration injection declarative, type-safe, and validated at build-time.
+
+## 2. `@Value` Decorator
+
+### 2.1 Usage
+```typescript
+@Injectable()
+export class NotificationService {
+  @Value('notification.retryCount', 3) // key, default value
+  private retryLimit: number;
+
+  @Value('notification.senderEmail')
+  private sender: string;
+}
+```
+
+### 2.2 Mechanism
+1. **Metadata Registration**: The decorator registers the property with a special `isConfig` flag in the `PROPERTY_DEPENDENCY` metadata.
+2. **Build-Time Validation**: During `cdk synth`, the `DIExplorer` traces these `@Value` injections and verifies that the keys exist in the `DIContainer`'s config providers.
+3. **Runtime Injection**: The `DIContainer.resolve` method detects the `isConfig` flag and uses `resolveConfig(token)` to populate the property.
+
+## 3. `@ConfigurationProperties` Decorator
+
+### 3.1 Usage
+```typescript
+@ConfigurationProperties('app.mail')
+export class MailConfig {
+  host: string;
+  port: number;
+  secure: boolean = true;
+}
+
+@Injectable()
+export class Mailer {
+  constructor(private config: MailConfig) {}
+}
+```
+
+### 3.2 Mechanism
+1. **Metadata Registration**: The `@ConfigurationProperties(prefix)` decorator marks the class.
+2. **Provider Generation**: The framework automatically registers a factory provider for this class that:
+    - Resolves the configuration at `prefix`.
+    - Instantiates the class.
+    - Maps the config object to the class properties.
+3. **Build-Time Validation**: Validates that the config object at `prefix` contains all required properties (those without defaults).
+
+## 4. Technical Implementation
+
+### 4.1 Decorator Definitions
+```typescript
+export function Value(token: string, defaultValue?: any) {
+  return function(target: any, propertyKey: string | symbol) {
+    registerPropertyDependency(target.constructor, propertyKey, token, {
+        isConfig: true,
+        defaultValue
+    });
+  };
+}
+
+export function ConfigurationProperties(prefix: string) {
+  return function(target: Function) {
+    registerModuleMetadata(target, {
+       providers: [{
+          provide: target,
+          useFactory: (container: IDIContainer) => {
+              const config = container.resolveConfig(prefix);
+              return Object.assign(new (target as any)(), config);
+          }
+       }]
+    });
+  };
+}
+```
+
+## 5. Benefits
+- **Fail-Fast**: Missing configuration is caught during `cdk synth`, preventing runtime Lambda errors.
+- **Type Safety**: Developers interact with typed objects rather than string-keyed maps.
+- **Readability**: Dependencies and configurations are clearly declared at the top of the class.


### PR DESCRIPTION
This submission documents the finalized roadmap for FW24's next major evolution. It captures the transition from a runtime-heavy resolution model to an intelligent Build-Time DI Explorer that automates IAM provisioning, resource discovery, and configuration management. This plan aims to dramatically reduce developer boilerplate while strengthening the framework's security-by-default posture.

---
*PR created automatically by Jules for task [3082163201792000049](https://jules.google.com/task/3082163201792000049) started by @Nitinrajyadav*