### PR TITLE
feat(observability): add Logtrail backend for observability events

### DIFF
--- a/src/logging/index.ts
+++ b/src/logging/index.ts
@@ -82,5 +82,6 @@ export {
     logtrailTransport,
     resolveLogtrailVectorIngest,
     setLogtrailVectorIngest,
+    shipLogtrailVectorJson,
     type LogtrailVectorIngestConfig,
 } from './logtrail';

--- a/src/logging/logtrail.ts
+++ b/src/logging/logtrail.ts
@@ -75,6 +75,35 @@ function resolvedHost(cfg: LogtrailVectorIngestConfig): string {
     return h ?? "unknown";
 }
 
+/**
+ * Fire-and-forget POST of one Vector JSON object (`service`, `level`, `host`, `message`).
+ * Used by tslog transport and observability Logtrail backend.
+ */
+export function shipLogtrailVectorJson(payload: {
+    level: string;
+    message: string;
+    /** Overrides Loki `service` label when ingest is configured */
+    service?: string;
+}): void {
+    const cfg = resolveLogtrailVectorIngest();
+    if (!cfg) return;
+    const msg = payload.message.trim();
+    if (!msg) return;
+
+    const service = payload.service?.trim() ? payload.service.trim() : cfg.service;
+    const body = JSON.stringify({
+        service,
+        host: resolvedHost(cfg),
+        level: payload.level,
+        message: msg,
+    });
+
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    if (cfg.xApiKey) headers[ "x-api-key" ] = cfg.xApiKey;
+
+    void fetch(cfg.ingestHttpUrl, { method: "POST", headers, body }).catch(() => { });
+}
+
 function serializeLogPayload(logObj: ILogObj & ILogObjMeta): string {
     try {
         const seen = new WeakSet<object>();
@@ -104,21 +133,9 @@ function levelFromTslog(logObj: ILogObj & ILogObjMeta): string {
 
 /** Fire-and-forget POST to Vector. Attach with logger.attachTransport(...) */
 export function logtrailTransport(logObj: ILogObj & ILogObjMeta): void {
-    const cfg = resolveLogtrailVectorIngest();
-    if (!cfg) return;
-
     const message = serializeLogPayload(logObj);
-    if (message === "") return;
-
-    const body = JSON.stringify({
-        service: cfg.service,
-        host: resolvedHost(cfg),
+    shipLogtrailVectorJson({
         level: levelFromTslog(logObj),
         message,
     });
-
-    const headers: Record<string, string> = { "Content-Type": "application/json" };
-    if (cfg.xApiKey) headers[ "x-api-key" ] = cfg.xApiKey;
-
-    void fetch(cfg.ingestHttpUrl, { method: "POST", headers, body }).catch(() => { });
 }

--- a/src/observability/backends/index.ts
+++ b/src/observability/backends/index.ts
@@ -1,3 +1,4 @@
 export * from './cloudwatch';
 export * from './dynamodb';
 export * from './otel';
+export * from './logtrail';

--- a/src/observability/backends/logtrail.ts
+++ b/src/observability/backends/logtrail.ts
@@ -1,0 +1,60 @@
+/**
+ * Ships observability events to Logtrail’s Vector HTTP source (same contract as tslog logging).
+ */
+
+import { Injectable, InjectConfig } from '../../di';
+import { shipLogtrailVectorJson } from '../../logging/logtrail';
+import type { ObservabilityBackend, ObservabilityBackendConfig, ObservabilityEvent } from '../types';
+import { ObservabilityLevel } from '../types';
+import { safeSerialize } from '../utils/payload';
+
+@Injectable({
+  provide: 'ObservabilityBackend',
+  providedIn: 'ROOT',
+  tags: [ 'observability', 'backend', 'logtrail' ],
+})
+export class LogtrailObservabilityBackend implements ObservabilityBackend {
+  public readonly name = 'logtrail' as const;
+  public readonly minLevel?: ObservabilityLevel;
+
+  private serviceLabelOverride: string | undefined;
+
+  constructor(
+    @InjectConfig('observability.minLevel') minLevel: ObservabilityLevel,
+  ) {
+    this.minLevel = minLevel;
+  }
+
+  configureFromBackendEntry(entry: ObservabilityBackendConfig): void {
+    if (entry.type !== 'logtrail') return;
+    const s = entry.config?.service?.trim();
+    this.serviceLabelOverride = s || undefined;
+  }
+
+  async capture(event: ObservabilityEvent): Promise<void> {
+    if (event.type === 'span.start') {
+      return;
+    }
+
+    const levelStr = event.level.toLowerCase();
+
+    try {
+      const payload = safeSerialize(event, { maxLength: 256 * 1024 });
+      const message = typeof payload === 'string'
+        ? payload
+        : JSON.stringify(payload);
+
+      shipLogtrailVectorJson({
+        level: levelStr,
+        message,
+        ...(this.serviceLabelOverride ? { service: this.serviceLabelOverride } : {}),
+      });
+    } catch {
+      shipLogtrailVectorJson({
+        level: levelStr || 'info',
+        message: JSON.stringify({ _fw24: 'observability_serialize_failed', type: event.type }),
+        ...(this.serviceLabelOverride ? { service: this.serviceLabelOverride } : {}),
+      });
+    }
+  }
+}

--- a/src/observability/config.ts
+++ b/src/observability/config.ts
@@ -38,7 +38,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 /**
  * Valid backend types
  */
-export const VALID_BACKENDS = [ 'cloudwatch', 'dynamodb', 'otel' ] as const;
+export const VALID_BACKENDS = [ 'cloudwatch', 'dynamodb', 'otel', 'logtrail' ] as const;
 export type ValidBackend = typeof VALID_BACKENDS[ number ];
 
 /**
@@ -387,9 +387,9 @@ function normalizeTypeSpecificConfig(input?: DeepPartial<TypeSpecificConfig>): T
     sampling = { enabled: samplingIn.enabled, rate: samplingIn.rate };
   }
 
-  type BackendName = 'cloudwatch' | 'dynamodb' | 'otel';
+  type BackendName = 'cloudwatch' | 'dynamodb' | 'otel' | 'logtrail';
   const isValidBackend = (v: unknown): v is BackendName =>
-    v === 'cloudwatch' || v === 'dynamodb' || v === 'otel';
+    v === 'cloudwatch' || v === 'dynamodb' || v === 'otel' || v === 'logtrail';
 
   const backends = Array.isArray(input.backends)
     ? input.backends.filter(isValidBackend)
@@ -513,7 +513,7 @@ function normalizeNoiseReduction(
   const isAggressive = presetLevel === 'aggressive';
 
   const presets = Array.isArray(input?.presets)
-    ? input.presets.filter((p): p is NoiseReductionConfig['presets'][number] => typeof p === 'string')
+    ? input.presets.filter((p): p is NoiseReductionConfig[ 'presets' ][ number ] => typeof p === 'string')
     : d.presets;
 
   const rules: NoiseRule[] = Array.isArray(input?.rules)
@@ -523,7 +523,7 @@ function normalizeNoiseReduction(
         && typeof r.decision === 'string'
         && isRecord(r.match);
     }) as NoiseRule[])
-    : [...d.rules];
+    : [ ...d.rules ];
 
   // Normalize hardSignals to ensure slowThresholds has no undefined values
   const hardSignalInput = input?.hardSignals;
@@ -534,7 +534,7 @@ function normalizeNoiseReduction(
     slowThresholdMs: hardSignalInput.slowThresholdMs ?? aggressiveHS?.slowThresholdMs,
     slowThresholds: hardSignalInput.slowThresholds
       ? Object.fromEntries(
-        Object.entries(hardSignalInput.slowThresholds).filter(([_, v]) => v !== undefined),
+        Object.entries(hardSignalInput.slowThresholds).filter(([ _, v ]) => v !== undefined),
       ) as Record<string, number>
       : undefined,
   } : {
@@ -642,6 +642,18 @@ function normalizeBackends(
           config: b.config,
           types: b.types,
         };
+      case 'logtrail':
+        return {
+          type: 'logtrail',
+          enabled: b.enabled ?? true,
+          minLevel: b.minLevel,
+          config: b.config,
+          types: b.types,
+        };
+      default: {
+        const t = (b as { type?: unknown }).type;
+        throw new Error(`Invalid observability backend type: ${String(t)}`);
+      }
     }
   });
 }

--- a/src/observability/index.ts
+++ b/src/observability/index.ts
@@ -62,6 +62,7 @@ export {
   type ObservabilityConfig,
   type ObservabilityBackend,
   type ObservabilityBackendConfig,
+  type ObservabilityBackendName,
   type DataProtectionConfig,
   type TruncationConfig,
   type DynamoDBConfig,
@@ -216,6 +217,7 @@ export {
 export { CloudWatchBackend } from './backends/cloudwatch';
 export { DynamoDBObservabilityBackend } from './backends/dynamodb';
 export { OTELObservabilityBackend } from './backends/otel';
+export { LogtrailObservabilityBackend } from './backends/logtrail';
 
 // === UTILITIES ===
 export { clearRedactorCache, DEFAULT_BLACKLISTED_KEYS, DEFAULT_PROTECTED_FIELDS, extendBlacklist, redactSensitiveData, shouldRedactKey } from './utils/data-protection';

--- a/src/observability/manager.ts
+++ b/src/observability/manager.ts
@@ -9,6 +9,7 @@ import { createLogger } from '../logging';
 import {
   CaptureControl,
   CaptureInput,
+  type ObservabilityBackendName,
   ObservabilityBackend,
   ObservabilityConfig,
   ObservabilityError,
@@ -86,7 +87,7 @@ function unpackEmittedEvents(emittedEvents: readonly EmittedEvent[]): Observabil
       let checkpoints = (existingData.checkpoints as unknown[]) ?? [];
       if (emitted.absorbed.checkpoints.length > 0) {
         const groupedEntries = groupCheckpointsByOperation(emitted.absorbed.checkpoints);
-        checkpoints = [...checkpoints, ...groupedEntries];
+        checkpoints = [ ...checkpoints, ...groupedEntries ];
       }
 
       // Store absorbed summary — stripped of byOperation, entityIds, and checkpoints
@@ -336,7 +337,8 @@ function getBackendsForType(type: string): ObservabilityBackend[] {
   const typeConfig = config?.types?.[ typeCategory ];
 
   if (typeConfig?.backends && typeConfig.backends.length > 0) {
-    return backends.filter((b) => typeConfig.backends!.includes(b.name as 'cloudwatch' | 'dynamodb' | 'otel'));
+    return backends.filter((b) =>
+      typeConfig.backends!.includes(b.name as ObservabilityBackendName));
   }
 
   return backends;
@@ -351,7 +353,7 @@ function shouldBackendCaptureType(
 ): boolean {
   // Per-event backend filter (used for OTEL span tracking in consolidated mode)
   if (event.capture?.backends && event.capture.backends.length > 0) {
-    if (!event.capture.backends.includes(backend.name as 'cloudwatch' | 'dynamodb' | 'otel')) {
+    if (!event.capture.backends.includes(backend.name as ObservabilityBackendName)) {
       return false;
     }
   }
@@ -1109,6 +1111,7 @@ function initializeBackendsFromConfig(cfg: ObservabilityConfig): void {
       );
       backends.push(backend);
       backendConfigs.set(backend.name, backendCfg);
+      backend.configureFromBackendEntry?.(backendCfg);
       logger.debug(`Initialized backend: ${backend.name}`);
     } catch (error) {
       if (error instanceof NoProviderFoundError) {
@@ -1582,8 +1585,8 @@ export class ObservabilityManager {
           const summaryByLevel: Record<string, number> = {};
           let errorCount = 0;
           for (const e of maybeDropEmptyLeafSpans) {
-            summaryByType[e.type] = (summaryByType[e.type] || 0) + 1;
-            summaryByLevel[e.level] = (summaryByLevel[e.level] || 0) + 1;
+            summaryByType[ e.type ] = (summaryByType[ e.type ] || 0) + 1;
+            summaryByLevel[ e.level ] = (summaryByLevel[ e.level ] || 0) + 1;
             if (e.level === 'error' || e.level === 'critical') errorCount++;
           }
           rootSpan.data = {
@@ -1624,11 +1627,11 @@ export class ObservabilityManager {
           }
 
           // Track captured event breakdowns
-          capturedByType[event.type] = (capturedByType[event.type] || 0) + 1;
+          capturedByType[ event.type ] = (capturedByType[ event.type ] || 0) + 1;
           if (event.operation) {
-            capturedByOperation[event.operation] = (capturedByOperation[event.operation] || 0) + 1;
+            capturedByOperation[ event.operation ] = (capturedByOperation[ event.operation ] || 0) + 1;
           }
-          capturedByLevel[event.level] = (capturedByLevel[event.level] || 0) + 1;
+          capturedByLevel[ event.level ] = (capturedByLevel[ event.level ] || 0) + 1;
           obsState.summary.captured++;
 
           // Passed both filtering and sampling - emit

--- a/src/observability/types.ts
+++ b/src/observability/types.ts
@@ -31,6 +31,15 @@ export enum ObservabilityLevel {
 export type ObservabilityLevelString = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'critical';
 
 /**
+ * Persistence / export backends configured under {@link ObservabilityConfig.backends}.
+ */
+export type ObservabilityBackendName =
+  | 'cloudwatch'
+  | 'dynamodb'
+  | 'otel'
+  | 'logtrail';
+
+/**
  * Base event types supported by the framework
  */
 export type BaseEventType =
@@ -215,7 +224,7 @@ export interface CaptureControl {
    * Used internally for OTEL span tracking in consolidated mode.
    * @internal
    */
-  backends?: ('cloudwatch' | 'dynamodb' | 'otel')[];
+  backends?: ObservabilityBackendName[];
 }
 
 /**
@@ -572,7 +581,7 @@ export interface CaptureInput {
  */
 export interface ObservabilityBackend {
   /** Unique backend name */
-  name: string;
+  name: ObservabilityBackendName | string;
   /** Minimum level to capture (optional filtering) */
   minLevel?: ObservabilityLevel;
   /** Capture an event */
@@ -581,6 +590,11 @@ export interface ObservabilityBackend {
   flush?(): Promise<void>;
   /** Initialize for new invocation (called on each Lambda invocation) */
   initializeInvocation?(): void;
+  /**
+   * Called once after DI resolution with this backend's entry from `observability.backends`.
+   * Optional hooks for backends that read per-entry options (e.g. Logtrail `service` label override).
+   */
+  configureFromBackendEntry?(entry: ObservabilityBackendConfig): void;
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -690,6 +704,14 @@ export interface OTELBackendOptions {
 }
 
 /**
+ * Logtrail (Vector HTTP JSON ingest) backend — URL/credentials via `LOGTRAIL_*` env (see `@ten24group/fw24` logging Logtrail helpers).
+ */
+export interface LogtrailBackendOptions {
+  /** Overrides the Loki `service` label; default is `LOGTRAIL_SERVICE` when ingest is enabled */
+  service?: string;
+}
+
+/**
  * Per-type backend filtering
  * Allows control over which event types this backend receives
  */
@@ -708,13 +730,14 @@ export interface BackendTypeFilter {
 export type ObservabilityBackendConfig =
   | { type: 'cloudwatch'; enabled: boolean; minLevel?: ObservabilityLevel; config?: CloudWatchBackendOptions; types?: { span?: BackendTypeFilter; metric?: BackendTypeFilter; audit?: BackendTypeFilter; log?: BackendTypeFilter } }
   | { type: 'dynamodb'; enabled: boolean; minLevel?: ObservabilityLevel; config?: DynamoDBBackendOptions; types?: { span?: BackendTypeFilter; metric?: BackendTypeFilter; audit?: BackendTypeFilter; log?: BackendTypeFilter } }
-  | { type: 'otel'; enabled: boolean; minLevel?: ObservabilityLevel; config?: OTELBackendOptions; types?: { span?: BackendTypeFilter; metric?: BackendTypeFilter; audit?: BackendTypeFilter; log?: BackendTypeFilter } };
+  | { type: 'otel'; enabled: boolean; minLevel?: ObservabilityLevel; config?: OTELBackendOptions; types?: { span?: BackendTypeFilter; metric?: BackendTypeFilter; audit?: BackendTypeFilter; log?: BackendTypeFilter } }
+  | { type: 'logtrail'; enabled: boolean; minLevel?: ObservabilityLevel; config?: LogtrailBackendOptions; types?: { span?: BackendTypeFilter; metric?: BackendTypeFilter; audit?: BackendTypeFilter; log?: BackendTypeFilter } };
 
 /**
  * Type-specific configuration
  */
 export interface TypeSpecificConfig {
-  backends?: ('cloudwatch' | 'dynamodb' | 'otel')[];
+  backends?: ObservabilityBackendName[];
   minLevel?: ObservabilityLevel;
   sampling?: {
     enabled: boolean;


### PR DESCRIPTION
- Introduced LogtrailObservabilityBackend to ship observability events to Logtrail's Vector HTTP source.
- Updated configuration to support Logtrail as a valid backend type.
- Added shipLogtrailVectorJson function for sending JSON payloads to Logtrail.
- Enhanced existing observability infrastructure to accommodate new backend integration.