### PR TITLE
ci(develop): fix beta release when remote tag already exists

### DIFF
--- a/.github/workflows/develop-release.yml
+++ b/.github/workflows/develop-release.yml
@@ -1,7 +1,8 @@
 name: Develop Branch Release
 
 # Requires repo secret DEVELOP_RELEASE_TOKEN (PAT with contents write; account must be allowed to push develop).
-# Checkout uses that token so `npm run release:BE:github` can push develop and tags.
+# Checkout uses that token for git push. If the next beta tag already exists remotely, CI bumps to
+# the next free prerelease and runs standard-version --release-as (existing tags are not deleted).
 # Release commits include [skip ci] via .versionrc.json so the automation push does not re-trigger this job.
 on:
   push:
@@ -84,5 +85,12 @@ jobs:
             echo "Committed dist folder"
           fi
 
+      - name: Next beta version (skip if tag already exists)
+        id: next_rel
+        run: echo "version=$(node scripts/ci/next-free-beta-version.cjs)" >> "$GITHUB_OUTPUT"
+
+      # CI uses --release-as (not --prerelease) when combined with a pinned version. One build above is enough.
       - name: Release beta (version, changelog, tag, push)
-        run: npm run release:BE:github
+        run: |
+          npm run release:BE:version:as -- --release-as "${{ steps.next_rel.outputs.version }}"
+          git push origin develop --follow-tags

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
         "test": "jest",
         "release": "npm run build && standard-version && git push --follow-tags && npm publish",
         "release:BE:version:bump": "standard-version --prerelease beta",
+        "release:BE:version:as": "standard-version",
+        "release:BE:next-free-beta": "node scripts/ci/next-free-beta-version.cjs",
         "release:BE:github": "npm run build && npm run release:BE:version:bump && git push --follow-tags",
         "release:BE": "npm run release:BE:github && npm publish --tag bleeding-edge",
         "layer:build": "esbuild --bundle --platform=node --sourcemap ./src/layer/fw24.ts --outdir=dist/layer/nodejs/node_modules",

--- a/scripts/ci/next-free-beta-version.cjs
+++ b/scripts/ci/next-free-beta-version.cjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+/**
+ * Print the next 1.1.0-beta.N semver such that refs/tags/v<that> does not exist locally
+ * or on origin (avoids standard-version failing when a tag was pushed but develop was not).
+ */
+'use strict';
+
+const { execSync } = require('child_process');
+const fs = require('fs');
+const semver = require('semver');
+
+const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+
+function tagExists(tagName) {
+  const ref = `refs/tags/${tagName}`;
+  try {
+    execSync(`git rev-parse -q --verify "${ref}"`, { stdio: 'ignore' });
+    return true;
+  } catch (_) {}
+  try {
+    const out = execSync(`git ls-remote origin "${ref}"`, { encoding: 'utf8' });
+    return out.trim().length > 0;
+  } catch {
+    return false;
+  }
+}
+
+let candidate = semver.inc(pkg.version, 'prerelease', 'beta');
+if (!candidate) {
+  throw new Error(`cannot bump prerelease from ${pkg.version}`);
+}
+let steps = 0;
+while (tagExists(`v${candidate}`)) {
+  if (++steps > 500) {
+    throw new Error('too many occupied prerelease tags');
+  }
+  const next = semver.inc(candidate, 'prerelease', 'beta');
+  if (!next || semver.eq(next, candidate)) {
+    throw new Error(`stuck at ${candidate}`);
+  }
+  candidate = next;
+}
+
+process.stdout.write(candidate);


### PR DESCRIPTION
## What broke

[Run 25668325711](https://github.com/ten24group/fw24/actions/runs/25668325711): `standard-version` failed with **`fatal: tag 'v1.1.0-beta.32' already exists`** — an older run had pushed that tag but not landed commits on `develop`, so `package.json` stayed on `beta.31` while the tag remained.

PR #278 simplified the workflow to `npm run release:BE:github` only, which **removed** the occupied-tag handling we had added earlier.

## Fix (best overall shape)

- **PAT + push `develop`** (unchanged from #278): org rules still require a token that may push `develop`.
- **Never delete tags**: advance `1.1.0-beta.N` until `v…` is free (same behavior as before the simplification).
- **`standard-version --release-as <ver>` only** — do not combine with `--prerelease beta` (that combo ignores the explicit version).
- **One `tsc` build** before release (the extra build inside the old npm script was redundant).
- Resolver lives in **`scripts/ci/next-free-beta-version.cjs`** so the workflow stays short; **`npm run release:BE:next-free-beta`** runs it locally for debugging.
- **`.versionrc.json`** `[skip ci]` on release commits (already on `develop` from #278) — unchanged here.

## Files

- `.github/workflows/develop-release.yml` — wire resolver + release steps.
- `scripts/ci/next-free-beta-version.cjs` — semver + `git ls-remote` / local tag check.
- `package.json` — `release:BE:next-free-beta` script.