### PR TITLE
chore(release): 1.1.0-beta.38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.1.0-beta.38](https://github.com/ten24group/fw24/compare/v1.1.0-beta.31...v1.1.0-beta.38) (2026-05-12)
+
+
+### Features
+
+* **logging:** integrate Logtrail transport for enhanced logging capabilities ([efe3fef](https://github.com/ten24group/fw24/commit/efe3feff373d33693250cce703c985ee6ccd96af))
+* **observability:** add Logtrail backend for observability events ([e309aa5](https://github.com/ten24group/fw24/commit/e309aa56a187eb26795ffd6d3f53711e3c1b6964))
+
+
+### Bug Fixes
+
+* sync dist with tsc and harden develop-release empty commit ([7e1c892](https://github.com/ten24group/fw24/commit/7e1c89229319d470859899413d30246b5848572a))
+
+## [1.1.0-beta.23](https://github.com/ten24group/fw24/compare/v1.1.0-beta.21...v1.1.0-beta.23) (2026-03-24)
+
+
+### Features
+
+* **utils:** move IAM managed policy chunking to utils ([6a5ad82](https://github.com/ten24group/fw24/commit/6a5ad829c7ed6f4b618cb7e70acec1a210541696))
+
+## [1.1.0-beta.21](https://github.com/ten24group/fw24/compare/v1.1.0-beta.20...v1.1.0-beta.21) (2026-03-24)
+
 ## [1.1.0-beta.36](https://github.com/ten24group/fw24/compare/v1.1.0-beta.31...v1.1.0-beta.36) (2026-05-12)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ten24group/fw24",
-    "version": "1.1.0-beta.36",
+    "version": "1.1.0-beta.38",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@ten24group/fw24",
-            "version": "1.1.0-beta.36",
+            "version": "1.1.0-beta.38",
             "license": "MIT",
             "dependencies": {
                 "@aws-cdk/aws-amplify-alpha": "^2.202.0-alpha.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@ten24group/fw24",
     "description": "A modern, serverless, framework to launch software products quickly and scale seamlessly",
-    "version": "1.1.0-beta.36",
+    "version": "1.1.0-beta.38",
     "main": "./dist/package/fw24.js",
     "types": "./dist/package/fw24.d.ts",
     "repository": {


### PR DESCRIPTION
Automated release from `develop` (workflow [25768700486](https://github.com/ten24group/fw24/actions/runs/25768700486)).

- **Tag** `v1.1.0-beta.38` has been pushed.
- This branch contains the version bump (`1.1.0-beta.38`), changelog, and any `dist` updates.
- **Merge this PR** to update `develop` (nothing pushes to `develop` from Actions).

The merge commit message includes `ci/release-`, so merging does **not** re-trigger this workflow.
