### PR TITLE
fix(entity): default list/query pagination to all pages

### DIFF
--- a/src/entity/base-entity-controller.ts
+++ b/src/entity/base-entity-controller.ts
@@ -269,7 +269,11 @@ export class BaseEntityController<Sch extends EntitySchema<any, any, any>> exten
 			cursor: cursor ?? null,
 			count: safeParseInt(count, 12).value,
 			limit: safeParseInt(limit, 250).value,
-			pages: pages === 'all' ? 'all' as const : safeParseInt(pages, 1).value,
+			// Default to 'all' pages so a result spanning multiple DynamoDB pages
+			// isn't silently truncated. The `count` default above still bounds the
+			// response size, so this only matters once a caller raises/removes `count`.
+			// An explicit numeric `pages` is still honoured.
+			pages: (pages == null || pages === 'all') ? 'all' as const : safeParseInt(pages, 1).value,
 		}
 
 		this.logger.debug(`parsed pagination`, pagination);

--- a/src/entity/crud-service.ts
+++ b/src/entity/crud-service.ts
@@ -701,7 +701,11 @@ export async function listEntity<S extends EntitySchema<any, any, any>>(options:
     const {
         filters = {},
         attributes = [],
-        pagination = { order: 'asc', pager: 'cursor', cursor: null, count: 25, pages: undefined, limit: undefined },
+        // Default to traversing all pages so service-level callers receive the
+        // complete result set. DynamoDB caps a single page at 1MB, so a bounded
+        // default would silently truncate larger results. Callers that want a
+        // bounded result should pass an explicit `count`/`limit`.
+        pagination = { order: 'asc', pager: 'cursor', cursor: null, pages: 'all' },
         index: specifiedIndex
     } = query;
 
@@ -807,7 +811,11 @@ export async function queryEntity<S extends EntitySchema<any, any, any>>(options
     const {
         filters = {},
         attributes = [],
-        pagination = { order: 'asc', pager: 'cursor', cursor: null, count: 25, pages: undefined, limit: undefined },
+        // Default to traversing all pages so service-level callers receive the
+        // complete result set. DynamoDB caps a single page at 1MB, so a bounded
+        // default would silently truncate larger results. Callers that want a
+        // bounded result should pass an explicit `count`/`limit`.
+        pagination = { order: 'asc', pager: 'cursor', cursor: null, pages: 'all' },
         index: specifiedIndex
     } = query;
 


### PR DESCRIPTION
## Problem

A single DynamoDB `Query`/`Scan` response is capped at **1 MB** regardless of the requested `limit` — DynamoDB returns the matching items up to that boundary plus a `LastEvaluatedKey` to continue. With the previous bounded pagination defaults, any result set larger than one page was **silently truncated**: callers received a partial list with no error and no indication that more data existed.

This is especially error-prone at the service level, where a caller writing `service.list({ filters })` reasonably expects the full result set but received only the default page.

## Change

**`listEntity` / `queryEntity`** — when a caller passes no `pagination`, default to `{ pages: 'all' }` so ElectroDB traverses pages until the query is exhausted and the caller receives the complete result set. Callers that want a bounded result pass an explicit `count` / `limit`.

**Base entity list controller** — default `pages` to `'all'` instead of `1`, so a result spanning multiple DynamoDB pages isn't truncated. The existing `count` default (page size) still bounds the response, so HTTP list endpoints remain bounded by default; `pages: 'all'` only takes effect once a caller raises or removes `count`. An explicit numeric `pages` is still honoured.

## Why `pages`, not `count`/`limit`

In ElectroDB, `count` is a hard cap on the number of *matching* items returned, and `limit` maps to DynamoDB's per-request `Limit` (items *evaluated*, not matched). Only `pages: 'all'` expresses "give me everything, paginating internally as needed" without imposing a ceiling. Leaving the `count` default in place on the controller keeps HTTP responses bounded while removing the silent-truncation footgun for unbounded service calls.

## Behavioural impact

- Service-level `list`/`query` calls with no pagination now return all matching rows instead of the first page. Add an explicit `count`/`limit` where a bounded result is desired.
- HTTP list endpoints are unchanged in default page size (still bounded by `count`); they no longer cap the traversal to a single page when `count` is raised.

## Notes

- `tsc --noEmit` clean; `crud-service` and base entity controller test suites pass.
- `{ pages: 'all' }` accumulates the full result set in memory; for very large tables a dedicated search/index path remains the appropriate approach.