### PR TITLE
fix(api-gateway): stable shared-root ownership for nested controllers

### DIFF
--- a/docs/nested-controller-shared-roots.md
+++ b/docs/nested-controller-shared-roots.md
@@ -1,0 +1,96 @@
+# Nested controllers & shared root segments
+
+## What this is about
+
+Controllers nested under a shared folder — e.g. `controllers/internal/notifications`,
+`controllers/internal/audit` — all serve routes under a shared path segment (`/internal`). fw24
+deploys each controller in its own CloudFormation **nested stack**, but the shared `/internal`
+segment is a single API Gateway resource that can only be created in **one** stack and referenced
+by the others.
+
+## How it works: one owner, decided by config — never by order
+
+The shared root segment is created **exactly once in a stable owner stack** and referenced by every
+sibling nested stack via its resource-id token (CDK wires it across stacks automatically). The owner
+is fixed by configuration, **never** by which controller registers first — so the segment's
+CloudFormation logical id is identical on every synth. This is what removes the historical failures:
+
+- **No more `409 AlreadyExists`** when a new controller sorts before an existing one — nobody races
+  to create `/internal`; siblings only reference it.
+- **No live AWS calls at synth** — synthesis stays deterministic and offline.
+- **No hardcoded root names** — any shared segment (`internal`, `admin`, `webhooks`, …) works.
+- **No "deploy twice"** — nested-controller apps set `deploy: false` and publish exactly one
+  `Deployment` + one `Stage` after every nested stack is registered, with `api.deploymentStage`
+  assigned so usage plans bind to a real stage.
+
+## Choosing a strategy
+
+Set `nestedControllerRootStrategy` on the API construct config. Default is `'main-stack'`. In every
+strategy the owner is decided up front (never by registration order), so the 409/ordering bug cannot
+occur, and no segment name is ever hardcoded.
+
+| Strategy | Best for | What you configure | Notes |
+|----------|----------|--------------------|-------|
+| `'main-stack'` *(default)* | **New apps** | Nothing | Main stack owns each root. Zero config, fully offline. An app already deployed with a root in a nested stack moves it once — see below. |
+| `'pinned'` | **Already-deployed apps** | `nestedControllerRootOwners: { internal: 'internal/team' }` | Root stays where it already is. Deterministic & offline; moves no live resource. Unlisted roots fall back to the main stack. |
+| `'auto'` | **Already-deployed apps in CI/CD** | Nothing | Looks up deployed CloudFormation at build time to discover the current owner (matched by route, not logical id) and keeps the root there. No config, moves no live resource — but the build needs AWS credentials. |
+
+**New app:** do nothing (`'main-stack'`). Add nested controllers in any order, several per deploy.
+
+**Already-deployed app — pick one:**
+
+- **`'auto'` — hands-off, fits CI/CD.** No config. At build time (where CI/CD already has the
+  target env's credentials) it queries CloudFormation, finds which controller stack currently owns
+  each root, and keeps the root there. Nothing is committed, nothing moves, the deploy doesn't fail.
+  Per-environment divergence is handled automatically (each env's build resolves its own state).
+  Caveats: the build **needs credentials** — a local `cdk diff` without them, or a genuinely
+  ambiguous/dirty deployed state, makes it **fail loud** (it never guesses). For those cases set a
+  `nestedControllerRootOwners` entry as an explicit fallback.
+- **`'pinned'` — explicit & offline.** Add one line per already-deployed root naming its current
+  stack. No credentials needed at build. You find the owner once by looking at the deployed stack
+  (the nested stack containing the `/internal` resource). Owners can differ per environment, so set
+  per-environment if they diverged.
+- **Cleanest end-state: keep the default and `cdk refactor` once per env** (below). Moves `/internal`
+  into the main stack so you carry no config or lookup afterward.
+
+## Cleaning up to the zero-config end-state (optional)
+
+Move `/internal` into the main stack **once per environment**, with that account's credentials.
+
+### Recommended: `cdk refactor` (declarative move, no recreate, zero downtime)
+
+```bash
+# 1. Build with the new fw24 version (code already targets main-stack ownership; no config needed).
+
+# 2. Preview the move: CDK compares the DEPLOYED stacks to the new synthesis and detects that
+#    /internal moved from the nested stack into the main stack.
+cdk refactor --dry-run
+
+# 3. Execute the move. CloudFormation relocates the existing /internal resource into the main stack
+#    WITHOUT deleting/recreating it. Child routes keep the same physical resource id throughout.
+cdk refactor
+
+# 4. From now on, deploy normally.
+cdk deploy
+```
+
+If `cdk refactor` cannot auto-match the resource, pass an explicit mapping file
+(`--mapping-file`) listing the old logical location → new logical location for the `/internal`
+resource. Validate on a non-production environment first.
+
+### Fallback: retain → orphan → import (if `cdk refactor` is unavailable)
+
+1. Add `RemovalPolicy.RETAIN` to the existing `/internal` resource in its current nested stack and
+   `cdk deploy` — so removing it later will not delete the physical resource.
+2. Switch to the new fw24 version (main-stack ownership) and `cdk deploy` the nested stack: it stops
+   declaring `/internal`, but the retained physical resource survives (now unmanaged).
+3. `cdk import` the existing `/internal` resource into the main stack, matching it by its API
+   Gateway resource id. No create, no 409.
+
+Both paths are zero-downtime: the `/internal` resource id never changes, so the child routes in
+other nested stacks keep resolving to it the whole time.
+
+### After migration
+
+Every environment owns `/internal` in the main stack — identical everywhere, no per-environment
+config, and you never think about shared-root ownership again.

--- a/docs/nested-controller-shared-roots.md
+++ b/docs/nested-controller-shared-roots.md
@@ -94,3 +94,20 @@ other nested stacks keep resolving to it the whole time.
 
 Every environment owns `/internal` in the main stack — identical everywhere, no per-environment
 config, and you never think about shared-root ownership again.
+
+## Known limitations (accepted)
+
+These are intentional boundaries — not gaps to fix in a follow-up redesign:
+
+- **`auto` needs build-time AWS credentials** — local `cdk synth` / `cdk diff` without credentials
+  for the target account will fail loud rather than guess an owner. Use `'pinned'` or
+  `nestedControllerRootOwners` as an explicit fallback for offline synth.
+- **Ambiguous deployed ownership fails loud** — if more than one nested stack already declares the
+  same root segment, lookup logs a warning and does not pick a winner silently.
+- **`auto` is mock-tested only in unit tests** — validate against real CloudFormation on a non-prod
+  environment before relying on `'auto'` in production CI.
+- **Brownfield one-time move** — apps that already deployed a shared root inside a nested stack need
+  either `'pinned'` / `'auto'`, or a one-time `cdk refactor` (or retain/import) to reach the
+  zero-config `'main-stack'` end state. This is migration work, not a deploy-order bug.
+- **Supersedes PR #289 / #263 approaches** — do not merge the older nested-controller migration
+  handler or synth-introspection lineages; this stable-root design is the supported path.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
                 "@aws-cdk/aws-amplify-alpha": "^2.202.0-alpha.0",
                 "@aws-lambda-powertools/logger": "^2.29.0",
                 "@aws-lambda-powertools/metrics": "^2.29.0",
+                "@aws-sdk/client-cloudformation": "^3.832.0",
                 "@aws-sdk/client-cloudwatch-logs": "^3.832.0",
                 "@aws-sdk/client-cognito-identity": "^3.830.0",
                 "@aws-sdk/client-cognito-identity-provider": "^3.830.0",
@@ -384,6 +385,295 @@
                 "@middy/core": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudformation": {
+            "version": "3.1071.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudformation/-/client-cloudformation-3.1071.0.tgz",
+            "integrity": "sha512-SibX2MXJzcH0SCpTCvYVWiMBI06kRHD3ZpHKT0CP445MVobdcSM+6ivBY7PdV9M71x4Y1CcuHhcl/wF2q3fHmg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "^3.974.22",
+                "@aws-sdk/credential-provider-node": "^3.972.57",
+                "@aws-sdk/types": "^3.973.13",
+                "@smithy/core": "^3.24.6",
+                "@smithy/fetch-http-handler": "^5.4.6",
+                "@smithy/node-http-handler": "^4.7.6",
+                "@smithy/types": "^4.14.3",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/core": {
+            "version": "3.974.22",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.22.tgz",
+            "integrity": "sha512-YofH63shc6YRdXjz80BJkpJW+Bkn0Cuu2dn4Rv7s9G2Idt58tgtzQEWxrR2xVljlVfIBeUjPuULnSVYLke3sUQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "^3.973.13",
+                "@aws-sdk/xml-builder": "^3.972.30",
+                "@aws/lambda-invoke-store": "^0.2.2",
+                "@smithy/core": "^3.24.6",
+                "@smithy/signature-v4": "^5.4.6",
+                "@smithy/types": "^4.14.3",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/credential-provider-env": {
+            "version": "3.972.48",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.48.tgz",
+            "integrity": "sha512-h6FEC95fbexUd6zxm4PdgS82bTcI2PRtUb2ZwMipb/Xr8bPwtf0G8rBo2jp7NA24Mbx2JA8/WingiYpA9RCCyw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.974.22",
+                "@aws-sdk/types": "^3.973.13",
+                "@smithy/core": "^3.24.6",
+                "@smithy/types": "^4.14.3",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/credential-provider-http": {
+            "version": "3.972.50",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.50.tgz",
+            "integrity": "sha512-lJO3OLpjvz5m/RSBQmsG/CEUGsvCy5ruxKwPQaOCqxqCMuyYT2BZwQUTDZVVwqQ9LrZKuK24JSa6r31hL/tvkg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.974.22",
+                "@aws-sdk/types": "^3.973.13",
+                "@smithy/core": "^3.24.6",
+                "@smithy/fetch-http-handler": "^5.4.6",
+                "@smithy/node-http-handler": "^4.7.6",
+                "@smithy/types": "^4.14.3",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/credential-provider-ini": {
+            "version": "3.972.55",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.55.tgz",
+            "integrity": "sha512-TBoF4buBGYhXjdZAryayY2TrkQj2B2KfE/msG4V53XCt+w0EhEwM2JRjx8p2grJ2C6gtH5++SAwEvGMRdi0yyw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.974.22",
+                "@aws-sdk/credential-provider-env": "^3.972.48",
+                "@aws-sdk/credential-provider-http": "^3.972.50",
+                "@aws-sdk/credential-provider-login": "^3.972.54",
+                "@aws-sdk/credential-provider-process": "^3.972.48",
+                "@aws-sdk/credential-provider-sso": "^3.972.54",
+                "@aws-sdk/credential-provider-web-identity": "^3.972.54",
+                "@aws-sdk/nested-clients": "^3.997.22",
+                "@aws-sdk/types": "^3.973.13",
+                "@smithy/core": "^3.24.6",
+                "@smithy/credential-provider-imds": "^4.3.7",
+                "@smithy/types": "^4.14.3",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/credential-provider-login": {
+            "version": "3.972.54",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.54.tgz",
+            "integrity": "sha512-hBWI3wZTdTGiuMfmPts6AWbAjFfRniOQnqx68tc2cQvRKWawFbN9wkLOVPWM1FAOyowZU73mC6Fi+rHSHNyLFw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.974.22",
+                "@aws-sdk/nested-clients": "^3.997.22",
+                "@aws-sdk/types": "^3.973.13",
+                "@smithy/core": "^3.24.6",
+                "@smithy/types": "^4.14.3",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/credential-provider-node": {
+            "version": "3.972.57",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.57.tgz",
+            "integrity": "sha512-u6dClpzNdWf1HGWz4wwhdXi1wiOofCLniM9S4BQQGlLAN9TW7VB+ld5V533GdKrYMaFeBGFqKnj0JCYvynLqwQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/credential-provider-env": "^3.972.48",
+                "@aws-sdk/credential-provider-http": "^3.972.50",
+                "@aws-sdk/credential-provider-ini": "^3.972.55",
+                "@aws-sdk/credential-provider-process": "^3.972.48",
+                "@aws-sdk/credential-provider-sso": "^3.972.54",
+                "@aws-sdk/credential-provider-web-identity": "^3.972.54",
+                "@aws-sdk/types": "^3.973.13",
+                "@smithy/core": "^3.24.6",
+                "@smithy/credential-provider-imds": "^4.3.7",
+                "@smithy/types": "^4.14.3",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/credential-provider-process": {
+            "version": "3.972.48",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.48.tgz",
+            "integrity": "sha512-w6VZwojPt12WnEkAUy6Nu4K6sWCbBmR7QX390b0nE6vRvkXbrYr9Lq9VySGkfjiMjpUA87op+J4EgvRmtWIDoQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.974.22",
+                "@aws-sdk/types": "^3.973.13",
+                "@smithy/core": "^3.24.6",
+                "@smithy/types": "^4.14.3",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/credential-provider-sso": {
+            "version": "3.972.54",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.54.tgz",
+            "integrity": "sha512-23uZpIpF2SIFDCa1fcWa202tK4gGeyvX6GIIAjiB8WBsvsVRBMnJ/7dCxHzxf7eZT7GToJg837LDIBnZsl/VUg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.974.22",
+                "@aws-sdk/nested-clients": "^3.997.22",
+                "@aws-sdk/token-providers": "3.1071.0",
+                "@aws-sdk/types": "^3.973.13",
+                "@smithy/core": "^3.24.6",
+                "@smithy/types": "^4.14.3",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/credential-provider-web-identity": {
+            "version": "3.972.54",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.54.tgz",
+            "integrity": "sha512-0Iv5QttS6wcATlodYKgvQj6B9Db51rx7NU9fqu0PoLeS4BIgdYMc/QK4smwLwpm5RFrs02V/eLyEFp3FklvlNQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.974.22",
+                "@aws-sdk/nested-clients": "^3.997.22",
+                "@aws-sdk/types": "^3.973.13",
+                "@smithy/core": "^3.24.6",
+                "@smithy/types": "^4.14.3",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/nested-clients": {
+            "version": "3.997.22",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.22.tgz",
+            "integrity": "sha512-4IwtcYSxEIVw5hcp8ogq0CMbFNZFw7jJUetpfFUhFFeqsa1K8j2Ihg2hnxLyOp3stMZnXda6VzOmPi1AFZQXcg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "^3.974.22",
+                "@aws-sdk/signature-v4-multi-region": "^3.996.35",
+                "@aws-sdk/types": "^3.973.13",
+                "@smithy/core": "^3.24.6",
+                "@smithy/fetch-http-handler": "^5.4.6",
+                "@smithy/node-http-handler": "^4.7.6",
+                "@smithy/types": "^4.14.3",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/signature-v4-multi-region": {
+            "version": "3.996.35",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.35.tgz",
+            "integrity": "sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "^3.973.13",
+                "@smithy/signature-v4": "^5.4.6",
+                "@smithy/types": "^4.14.3",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/token-providers": {
+            "version": "3.1071.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1071.0.tgz",
+            "integrity": "sha512-4LDW2Qob6LoLFuqYSYZq2AyTE9koSE9+i+n5UZcm10GpmQOK0zRD9L4uYlzItiTKksIWgC/qMFChAi3RvKYtMg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.974.22",
+                "@aws-sdk/nested-clients": "^3.997.22",
+                "@aws-sdk/types": "^3.973.13",
+                "@smithy/core": "^3.24.6",
+                "@smithy/types": "^4.14.3",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/types": {
+            "version": "3.973.13",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.13.tgz",
+            "integrity": "sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.14.3",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/xml-builder": {
+            "version": "3.972.30",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.30.tgz",
+            "integrity": "sha512-StElZPEoBquWwNqw1AcfpzEyZqJvFxouG+mpDNYlcH6ZOrqd2CuIryv+8LV8gNHZUOyKyJF3Dq9vxaXEmDR9TQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.14.3",
+                "fast-xml-parser": "5.7.3",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudformation/node_modules/fast-xml-parser": {
+            "version": "5.7.3",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+            "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@nodable/entities": "^2.1.0",
+                "fast-xml-builder": "^1.1.7",
+                "path-expression-matcher": "^1.5.0",
+                "strnum": "^2.2.3"
+            },
+            "bin": {
+                "fxparser": "src/cli/cli.js"
             }
         },
         "node_modules/@aws-sdk/client-cloudwatch-logs": {
@@ -3930,6 +4220,18 @@
                 "@tybys/wasm-util": "^0.10.0"
             }
         },
+        "node_modules/@nodable/entities": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
+            "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodable"
+                }
+            ],
+            "license": "MIT"
+        },
         "node_modules/@opentelemetry/api": {
             "version": "1.9.0",
             "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
@@ -4060,20 +4362,13 @@
             }
         },
         "node_modules/@smithy/core": {
-            "version": "3.23.0",
-            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.0.tgz",
-            "integrity": "sha512-Yq4UPVoQICM9zHnByLmG8632t2M0+yap4T7ANVw482J0W7HW0pOuxwVmeOwzJqX2Q89fkXz0Vybz55Wj2Xzrsg==",
+            "version": "3.25.1",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.25.1.tgz",
+            "integrity": "sha512-zpDbpXBCBsxfLtG2GEUyfgvHvSFrw5CwDZSNzL0v52gx/c3oPlPbm+7W7num8xs6vyiUBn+bvYPHcQDOXZynCQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/middleware-serde": "^4.2.9",
-                "@smithy/protocol-http": "^5.3.8",
-                "@smithy/types": "^4.12.0",
-                "@smithy/util-base64": "^4.3.0",
-                "@smithy/util-body-length-browser": "^4.2.0",
-                "@smithy/util-middleware": "^4.2.8",
-                "@smithy/util-stream": "^4.5.12",
-                "@smithy/util-utf8": "^4.2.0",
-                "@smithy/uuid": "^1.1.0",
+                "@aws-crypto/crc32": "5.2.0",
+                "@smithy/types": "^4.15.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -4081,15 +4376,13 @@
             }
         },
         "node_modules/@smithy/credential-provider-imds": {
-            "version": "4.2.8",
-            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.8.tgz",
-            "integrity": "sha512-FNT0xHS1c/CPN8upqbMFP83+ul5YgdisfCfkZ86Jh2NSmnqw/AJ6x5pEogVCTVvSm7j9MopRU89bmDelxuDMYw==",
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.1.tgz",
+            "integrity": "sha512-TSAF5NHgxEsllbErYWbK8aLnl5L601NGc5VYJlSPsKnf3YlkhdoBN+geGcaU00oiw2OK3QO5LA3QNXiiWhCidQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/node-config-provider": "^4.3.8",
-                "@smithy/property-provider": "^4.2.8",
-                "@smithy/types": "^4.12.0",
-                "@smithy/url-parser": "^4.2.8",
+                "@smithy/core": "^3.25.1",
+                "@smithy/types": "^4.15.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -4167,15 +4460,13 @@
             }
         },
         "node_modules/@smithy/fetch-http-handler": {
-            "version": "5.3.9",
-            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.9.tgz",
-            "integrity": "sha512-I4UhmcTYXBrct03rwzQX1Y/iqQlzVQaPxWjCjula++5EmWq9YGBrx6bbGqluGc1f0XEfhSkiY4jhLgbsJUMKRA==",
+            "version": "5.5.1",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.5.1.tgz",
+            "integrity": "sha512-96JrD1q71anokymx9Iblb+zKmNQYNstlV/25A9ZYIJ2A0rp1r7/GZAIm0bDWSmVvz3DpNOCZuabzsiL+w0UHhw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/protocol-http": "^5.3.8",
-                "@smithy/querystring-builder": "^4.2.8",
-                "@smithy/types": "^4.12.0",
-                "@smithy/util-base64": "^4.3.0",
+                "@smithy/core": "^3.25.1",
+                "@smithy/types": "^4.15.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -4361,15 +4652,13 @@
             }
         },
         "node_modules/@smithy/node-http-handler": {
-            "version": "4.4.10",
-            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.10.tgz",
-            "integrity": "sha512-u4YeUwOWRZaHbWaebvrs3UhwQwj+2VNmcVCwXcYTvPIuVyM7Ex1ftAj+fdbG/P4AkBwLq/+SKn+ydOI4ZJE9PA==",
+            "version": "4.8.1",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.8.1.tgz",
+            "integrity": "sha512-emtXvoky671puri18ETf64AFIQUGIEA093F2drXpBgB0OGnBLjcwNR3CA2mYu62IAqNsS56xa5lnTxAgPq7cjw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/abort-controller": "^4.2.8",
-                "@smithy/protocol-http": "^5.3.8",
-                "@smithy/querystring-builder": "^4.2.8",
-                "@smithy/types": "^4.12.0",
+                "@smithy/core": "^3.25.1",
+                "@smithy/types": "^4.15.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -4455,18 +4744,13 @@
             }
         },
         "node_modules/@smithy/signature-v4": {
-            "version": "5.3.8",
-            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.8.tgz",
-            "integrity": "sha512-6A4vdGj7qKNRF16UIcO8HhHjKW27thsxYci+5r/uVRkdcBEkOEiY8OMPuydLX4QHSrJqGHPJzPRwwVTqbLZJhg==",
+            "version": "5.5.1",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.5.1.tgz",
+            "integrity": "sha512-X9rVls3En0z3NtrmguTmpRM0/NqtWUxBjal6fcAkwtsub+gOdLZ6kD+V7xhUgFMGdG14bHbZ7M5QjaRI1+DatQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/is-array-buffer": "^4.2.0",
-                "@smithy/protocol-http": "^5.3.8",
-                "@smithy/types": "^4.12.0",
-                "@smithy/util-hex-encoding": "^4.2.0",
-                "@smithy/util-middleware": "^4.2.8",
-                "@smithy/util-uri-escape": "^4.2.0",
-                "@smithy/util-utf8": "^4.2.0",
+                "@smithy/core": "^3.25.1",
+                "@smithy/types": "^4.15.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -4492,9 +4776,9 @@
             }
         },
         "node_modules/@smithy/types": {
-            "version": "4.12.0",
-            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.12.0.tgz",
-            "integrity": "sha512-9YcuJVTOBDjg9LWo23Qp0lTQ3D7fQsQtwle0jVfpbUHy9qBwCEgKuVH4FqFB3VYu0nwdHKiEMA+oXz7oV8X1kw==",
+            "version": "4.15.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+            "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
@@ -5603,6 +5887,18 @@
             "engines": {
                 "node": ">= 8"
             }
+        },
+        "node_modules/anynum": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+            "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT"
         },
         "node_modules/arg": {
             "version": "4.1.3",
@@ -7617,6 +7913,22 @@
             "dev": true,
             "license": "MIT",
             "peer": true
+        },
+        "node_modules/fast-xml-builder": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+            "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "path-expression-matcher": "^1.5.0",
+                "xml-naming": "^0.1.0"
+            }
         },
         "node_modules/fast-xml-parser": {
             "version": "5.2.5",
@@ -10035,6 +10347,21 @@
                 "node": ">=8"
             }
         },
+        "node_modules/path-expression-matcher": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+            "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
         "node_modules/path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -11257,16 +11584,19 @@
             }
         },
         "node_modules/strnum": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
-            "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+            "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
             "funding": [
                 {
                     "type": "github",
                     "url": "https://github.com/sponsors/NaturalIntelligence"
                 }
             ],
-            "license": "MIT"
+            "license": "MIT",
+            "dependencies": {
+                "anynum": "^1.0.1"
+            }
         },
         "node_modules/supports-color": {
             "version": "7.2.0",
@@ -12031,6 +12361,21 @@
             },
             "engines": {
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/xml-naming": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+            "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=16.0.0"
             }
         },
         "node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
         "@aws-cdk/aws-amplify-alpha": "^2.202.0-alpha.0",
         "@aws-lambda-powertools/logger": "^2.29.0",
         "@aws-lambda-powertools/metrics": "^2.29.0",
+        "@aws-sdk/client-cloudformation": "^3.832.0",
         "@aws-sdk/client-cloudwatch-logs": "^3.832.0",
         "@aws-sdk/client-cognito-identity": "^3.830.0",
         "@aws-sdk/client-cognito-identity-provider": "^3.830.0",

--- a/src/constructs/api-nested-controller-stable-root.test.ts
+++ b/src/constructs/api-nested-controller-stable-root.test.ts
@@ -1,0 +1,282 @@
+import { App, NestedStack, Stack } from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { RestApi } from 'aws-cdk-lib/aws-apigateway';
+import { APIConstruct } from './api';
+import { Fw24 } from '../core/fw24';
+
+/**
+ * Behaviour contract for the stable shared-root approach to nested controllers:
+ *  - a shared root segment (e.g. `internal`) is created exactly once, in a STABLE owner stack,
+ *    regardless of controller registration order (no 409, no live AWS lookups);
+ *  - by default the main (RestApi) stack owns it; brownfield apps can pin ownership to an
+ *    existing nested stack to preserve the historical CloudFormation logical id;
+ *  - nested-controller apps publish exactly one deployment + one stage, and that stage is exposed
+ *    as api.deploymentStage so usage plans bind correctly.
+ */
+describe('APIConstruct nested controllers — stable shared root', () => {
+    let app: App;
+    let mainStack: Stack;
+
+    const newApiConstruct = (config: Record<string, unknown> = {}) => new APIConstruct({
+        controllerParentStackName: 'main',
+        skipControllers: true,
+        cors: true,
+        apiOptions: { deployOptions: { stageName: 'v1' } },
+        ...config,
+    } as any);
+
+    // Register a nested controller the way registerController does: ensure its stack exists,
+    // then resolve/attach its resources via getOrCreateControllerResource.
+    const registerNestedController = (api: APIConstruct, controllerName: string) => {
+        const fw24 = Fw24.getInstance();
+        fw24.getStack(controllerName, 'main');
+        return (api as any).getOrCreateControllerResource(controllerName, controllerName) as { resourceId: string };
+    };
+
+    const apiGatewayResourcesWithPathPart = (stack: Stack, pathPart: string) => {
+        const resources = Template.fromStack(stack).findResources('AWS::ApiGateway::Resource');
+        return Object.entries(resources).filter(([ , r ]) => (r as any).Properties?.PathPart === pathPart);
+    };
+
+    beforeEach(() => {
+        (Fw24 as any).instance = undefined;
+        app = new App();
+        mainStack = new Stack(app, 'test-app-main-stack', { env: { account: '123456789012', region: 'us-east-1' } });
+        const fw24 = Fw24.getInstance();
+        fw24.setApp(app);
+        fw24.setConfig({ name: 'test-app', region: 'us-east-1', account: '123456789012' } as any);
+        fw24.addStack('main', mainStack);
+    });
+
+    afterEach(() => {
+        (Fw24 as any).instance = undefined;
+        jest.restoreAllMocks();
+    });
+
+    describe('order independence', () => {
+        // Build a fresh app in the given registration order and return the single main-stack /internal
+        // logical id (asserting it is created exactly once, as a child of the API root).
+        const buildAndGetInternalRootLogicalId = async (order: string[]): Promise<string> => {
+            (Fw24 as any).instance = undefined;
+            const localApp = new App();
+            const localMain = new Stack(localApp, 'test-app-main-stack', { env: { account: '123456789012', region: 'us-east-1' } });
+            const fw24 = Fw24.getInstance();
+            fw24.setApp(localApp);
+            fw24.setConfig({ name: 'test-app', region: 'us-east-1', account: '123456789012' } as any);
+            fw24.addStack('main', localMain);
+
+            const api = newApiConstruct();
+            await api.construct();
+            for (const name of order) {
+                fw24.getStack(name, 'main');
+                (api as any).getOrCreateControllerResource(name, name);
+            }
+
+            const internalInMain = apiGatewayResourcesWithPathPart(localMain, 'internal');
+            expect(internalInMain).toHaveLength(1);
+            const [ logicalId, resource ] = internalInMain[ 0 ];
+            // child of the API root (ParentId -> RootResourceId), owned by the main stack
+            expect(JSON.stringify((resource as any).Properties?.ParentId)).toContain('RootResourceId');
+            // no sibling re-created /internal in its own nested stack
+            for (const name of order) {
+                expect(apiGatewayResourcesWithPathPart(fw24.getStack(name), 'internal')).toHaveLength(0);
+            }
+            return logicalId;
+        };
+
+        it('produces the SAME /internal logical id regardless of controller registration order', async () => {
+            const forwardOrder = await buildAndGetInternalRootLogicalId([ 'internal/team', 'internal/notifications' ]);
+            // reversed order — historically this is what flipped the owner and caused 409
+            const reversedOrder = await buildAndGetInternalRootLogicalId([ 'internal/notifications', 'internal/team' ]);
+            // a brand-new sibling that sorts first — the classic brownfield 409 trigger
+            const newSiblingFirst = await buildAndGetInternalRootLogicalId([ 'internal/audit', 'internal/team', 'internal/notifications' ]);
+
+            expect(reversedOrder).toBe(forwardOrder);
+            expect(newSiblingFirst).toBe(forwardOrder);
+        });
+    });
+
+    it('is generic — works for any shared root name, not just internal/admin', async () => {
+        const api = newApiConstruct();
+        await api.construct();
+        registerNestedController(api, 'webhooks/stripe');
+        registerNestedController(api, 'webhooks/razorpay');
+
+        expect(apiGatewayResourcesWithPathPart(mainStack, 'webhooks')).toHaveLength(1);
+    });
+
+    it('leaf resources live in their own nested stacks and reference the shared root by parameter', async () => {
+        const api = newApiConstruct();
+        await api.construct();
+        registerNestedController(api, 'internal/team');
+
+        const teamStack = Fw24.getInstance().getStack('internal/team') as NestedStack;
+        expect(teamStack instanceof NestedStack).toBe(true);
+        // the leaf segment is created in the nested stack...
+        expect(apiGatewayResourcesWithPathPart(teamStack, 'team')).toHaveLength(1);
+        // ...and its parent (/internal) is supplied cross-stack (a CfnParameter on the nested stack)
+        const params = Template.fromStack(teamStack).findParameters('*');
+        expect(Object.keys(params).length).toBeGreaterThan(0);
+    });
+
+    it('default strategy (main-stack): creates the shared root in the MAIN stack, never in a nested stack', async () => {
+        const api = newApiConstruct();
+        await api.construct();
+        registerNestedController(api, 'internal/team');
+        registerNestedController(api, 'internal/notifications');
+
+        expect(apiGatewayResourcesWithPathPart(mainStack, 'internal')).toHaveLength(1);
+        expect(apiGatewayResourcesWithPathPart(Fw24.getInstance().getStack('internal/team'), 'internal')).toHaveLength(0);
+        expect(apiGatewayResourcesWithPathPart(Fw24.getInstance().getStack('internal/notifications'), 'internal')).toHaveLength(0);
+    });
+
+    describe("'pinned' strategy (brownfield, moves no live resource)", () => {
+        it('keeps the shared root in the pinned owner stack, even when a non-owner registers first', async () => {
+            const api = newApiConstruct({
+                nestedControllerRootStrategy: 'pinned',
+                nestedControllerRootOwners: { internal: 'internal/team' },
+            });
+            await api.construct();
+            // a non-owner registers FIRST (the classic 409 trigger) — must still resolve to the owner
+            registerNestedController(api, 'internal/notifications');
+            registerNestedController(api, 'internal/team');
+
+            // /internal stays in the pinned owner stack, exactly once; main stack never creates it
+            expect(apiGatewayResourcesWithPathPart(Fw24.getInstance().getStack('internal/team'), 'internal')).toHaveLength(1);
+            expect(apiGatewayResourcesWithPathPart(mainStack, 'internal')).toHaveLength(0);
+        });
+
+        it('falls back to the main stack for roots not listed in the owners map', async () => {
+            const api = newApiConstruct({
+                nestedControllerRootStrategy: 'pinned',
+                nestedControllerRootOwners: { internal: 'internal/team' },
+            });
+            await api.construct();
+            registerNestedController(api, 'webhooks/stripe'); // not pinned -> main stack
+
+            expect(apiGatewayResourcesWithPathPart(mainStack, 'webhooks')).toHaveLength(1);
+        });
+    });
+
+    describe("'auto' strategy (discovers the existing owner from deployed state)", () => {
+        // a controller descriptor shaped like Helper.registerHandlers produces
+        const makeDescriptor = (fileName: string, controllerName: string) => {
+            class TestController { controllerName = controllerName; controllerConfig = {}; }
+            return { handlerClass: TestController, fileName, filePath: '/app/src/controllers', handlerHash: fileName } as any;
+        };
+        // a mocked CloudFormation lookup: `internal` is owned by a stack whose template carries the
+        // internal/team routes (so auto must resolve the owner to the internal/team controller stack)
+        const lookupOwnedByTeam = {
+            listNestedStacks: async () => [ { logicalId: 'someMangledNestedStackXYZ', physicalId: 'arn:team' } ],
+            getTemplate: async () => ({ Resources: {
+                Root: { Type: 'AWS::ApiGateway::Resource', Properties: { PathPart: 'internal', ParentId: { 'Fn::GetAtt': [ 'api', 'RootResourceId' ] } } },
+                Team: { Type: 'AWS::ApiGateway::Resource', Properties: { PathPart: 'team', ParentId: { Ref: 'Root' } } },
+            } }),
+        };
+
+        it('resolves the existing owner and keeps /internal there, even when a non-owner registers first', async () => {
+            const api = newApiConstruct({ nestedControllerRootStrategy: 'auto' });
+            await api.construct();
+            (api as any).nestedRootLookup = lookupOwnedByTeam;
+
+            await (api as any).resolveAutoSharedRootOwners([
+                makeDescriptor('internal/notifications.ts', 'notifications'),
+                makeDescriptor('internal/team.ts', 'team'),
+            ]);
+            // non-owner registers first (the classic 409 trigger)
+            registerNestedController(api, 'internal/notifications');
+            registerNestedController(api, 'internal/team');
+
+            expect(apiGatewayResourcesWithPathPart(Fw24.getInstance().getStack('internal/team'), 'internal')).toHaveLength(1);
+            expect(apiGatewayResourcesWithPathPart(mainStack, 'internal')).toHaveLength(0);
+            expect(apiGatewayResourcesWithPathPart(Fw24.getInstance().getStack('internal/notifications'), 'internal')).toHaveLength(0);
+        });
+
+        it('treats a not-yet-deployed (greenfield) root as main-stack owned', async () => {
+            const api = newApiConstruct({ nestedControllerRootStrategy: 'auto' });
+            await api.construct();
+            (api as any).nestedRootLookup = {
+                listNestedStacks: async () => [],   // nothing deployed owns anything
+                getTemplate: async () => ({}),
+            };
+
+            await (api as any).resolveAutoSharedRootOwners([ makeDescriptor('internal/team.ts', 'team') ]);
+            registerNestedController(api, 'internal/team');
+
+            expect(apiGatewayResourcesWithPathPart(mainStack, 'internal')).toHaveLength(1);
+        });
+
+        it('fails loud when the lookup cannot resolve and no fallback owner is configured', async () => {
+            const api = newApiConstruct({ nestedControllerRootStrategy: 'auto' });
+            await api.construct();
+            (api as any).nestedRootLookup = {
+                listNestedStacks: async () => { throw new Error('no credentials'); },
+                getTemplate: async () => ({}),
+            };
+
+            await expect((api as any).resolveAutoSharedRootOwners([ makeDescriptor('internal/team.ts', 'team') ]))
+                .rejects.toThrow(/could not look up deployed shared-root owners/);
+        });
+
+        it('uses a configured nestedControllerRootOwners value as an explicit fallback when lookup fails', async () => {
+            const api = newApiConstruct({ nestedControllerRootStrategy: 'auto', nestedControllerRootOwners: { internal: 'internal/team' } });
+            await api.construct();
+            (api as any).nestedRootLookup = {
+                listNestedStacks: async () => { throw new Error('no credentials'); },
+                getTemplate: async () => ({}),
+            };
+
+            await (api as any).resolveAutoSharedRootOwners([ makeDescriptor('internal/team.ts', 'team') ]);
+            registerNestedController(api, 'internal/team');
+
+            expect(apiGatewayResourcesWithPathPart(Fw24.getInstance().getStack('internal/team'), 'internal')).toHaveLength(1);
+            expect(apiGatewayResourcesWithPathPart(mainStack, 'internal')).toHaveLength(0);
+        });
+    });
+
+    describe('single deployment + stage', () => {
+        it('publishes exactly one deployment and one stage, and sets api.deploymentStage', async () => {
+            const api = newApiConstruct();
+            await api.construct();
+            registerNestedController(api, 'internal/team');
+
+            await (api as any).createSingleDeployment();
+
+            const template = Template.fromStack(mainStack);
+            template.resourceCountIs('AWS::ApiGateway::Deployment', 1);
+            template.resourceCountIs('AWS::ApiGateway::Stage', 1);
+            template.hasResourceProperties('AWS::ApiGateway::Stage', { StageName: 'v1' });
+            expect(api.api.deploymentStage).toBeDefined();
+        });
+
+        it('does not let RestApi auto-deploy a stage for nested-controller apps', async () => {
+            const api = newApiConstruct();
+            await api.construct();
+            // before createSingleDeployment runs, there must be no stage yet (deploy:false)
+            expect(() => Template.fromStack(mainStack).resourceCountIs('AWS::ApiGateway::Stage', 0)).not.toThrow();
+        });
+    });
+
+    describe('deferred usage plans bind to a real stage', () => {
+        it('creates a usage plan bound to the published stage (deploymentStage not undefined)', async () => {
+            const api = newApiConstruct({
+                usagePlans: [ { name: 'default', apiKeys: { keys: [ 'k-123456789012345678901234' ] } } ],
+            });
+            await api.construct();
+
+            // simulate the post-registration flow for a nested-controller app
+            await (api as any).createSingleDeployment();
+            (api as any).flushDeferredUsagePlans();
+
+            const template = Template.fromStack(mainStack);
+            template.resourceCountIs('AWS::ApiGateway::Stage', 1);
+            template.resourceCountIs('AWS::ApiGateway::UsagePlan', 1);
+            const usagePlans = template.findResources('AWS::ApiGateway::UsagePlan');
+            const apiStages = (Object.values(usagePlans)[ 0 ] as any).Properties?.ApiStages;
+            expect(Array.isArray(apiStages)).toBe(true);
+            expect(apiStages.length).toBe(1);
+            // the stage ref must resolve to a real stage, not undefined
+            expect(apiStages[ 0 ].Stage).toBeDefined();
+        });
+    });
+});

--- a/src/constructs/api.ts
+++ b/src/constructs/api.ts
@@ -14,6 +14,7 @@ import {
     Resource,
     ResponseType,
     RestApi,
+    Stage,
     ApiKey,
     Period,
     UsagePlan
@@ -30,6 +31,11 @@ import type { IFw24Module } from "../core/";
 import type HandlerDescriptor from "../interfaces/handler-descriptor";
 
 import { NodejsFunction, NodejsFunctionProps } from "aws-cdk-lib/aws-lambda-nodejs";
+import {
+    createCloudFormationNestedRootLookup,
+    NestedRootCloudFormationLookup,
+    resolveDeployedNestedRootOwners,
+} from "./nested-controller-root-lookup";
 import { Fw24 } from "../core/fw24";
 import { Helper } from "../core/helper";
 import { FW24Construct, FW24ConstructOutput, OutputType } from "../interfaces/construct";
@@ -137,6 +143,38 @@ export interface IAPIConstructConfig extends IConstructConfig {
     controllerParentStackName?: string;
 
     /**
+     * Ownership strategy for shared nested-controller root segments (the first path part of a
+     * nested route, e.g. `internal` in `internal/notifications`). In every strategy the owner is
+     * decided up front — never by controller registration order — so the shared resource's
+     * CloudFormation logical id is stable and the historical 409/ordering bug cannot occur. No
+     * hardcoded segment names in any strategy.
+     *
+     * - `'main-stack'` (default): the main RestApi stack owns every shared root. Zero config, fully
+     *   deterministic (no AWS calls) — new apps need nothing. An app already deployed with the root
+     *   in a nested stack moves it once per environment via `cdk refactor`.
+     * - `'pinned'`: a shared root stays in the controller stack that already owns it — you supply
+     *   `nestedControllerRootOwners`. Deterministic and offline; moves no live resource. Roots not
+     *   listed fall back to the main stack.
+     * - `'auto'`: at build time it looks up deployed CloudFormation to discover which controller
+     *   stack currently owns each root (matched by route, not logical id), and keeps it there. No
+     *   config and moves no live resource — but the build needs AWS credentials (present in CI/CD
+     *   deploy). It fails loud if it cannot resolve an owner (rather than guessing); set a
+     *   `nestedControllerRootOwners` entry as an explicit fallback for those cases.
+     *
+     * @default 'main-stack'
+     */
+    nestedControllerRootStrategy?: 'main-stack' | 'pinned' | 'auto';
+
+    /**
+     * The controller stack that already owns a shared root in the deployed app, e.g.
+     * `{ internal: 'internal/team' }`. Required with `'pinned'`; optional with `'auto'` as an
+     * explicit fallback when the lookup can't resolve (no creds / ambiguous / unmatched). The named
+     * stack keeps creating the root resource (preserving its existing CloudFormation logical id) and
+     * every sibling references it — so upgrading moves nothing and stays zero-downtime.
+     */
+    nestedControllerRootOwners?: Record<string, string>;
+
+    /**
      * Set to false if you want to skip creation of controllers resources and methods
      * This will delete all the controllers resources and methods from the API
      */
@@ -233,6 +271,22 @@ export class APIConstruct implements FW24Construct {
     private methods: Method[] = [];
     private readonly controllerStacks = new Map<string, { methods: Method[], resources: IResource[], controllersHash: string[] }>();
 
+    /**
+     * Shared root segments for nested controllers (e.g. `internal` for `internal/notifications`),
+     * each created exactly once in a STABLE owner stack and referenced by every sibling nested stack
+     * via the resource-id token. The owner is the main stack by default, or a pinned controller
+     * stack (`nestedControllerRootOwners`) for already-deployed apps. Either way the owner is fixed
+     * by config — never by registration order — so the segment's CloudFormation logical id is
+     * identical on every synth. No 409, no live AWS lookups.
+     */
+    private readonly sharedControllerRoots = new Map<string, { resource: IResource; ownerStack: Stack }>();
+    /** 'auto' strategy: resolved `rootSegment -> owning controller stack name`, discovered from deployed state. */
+    private readonly resolvedAutoRootOwners = new Map<string, string>();
+    /** Injectable CloudFormation lookup for the 'auto' strategy (overridable in tests). */
+    private nestedRootLookup?: NestedRootCloudFormationLookup;
+    /** True once an api-key usage plan was requested while deployment was still deferred. */
+    private deferredApiKeyPlanRequested = false;
+
     // default constructor to initialize the stack configuration
     constructor(private readonly apiConstructConfig: IAPIConstructConfig) {
         // hydrate the config object with environment variables ex: APIGATEWAY_CONTROLLERS
@@ -265,6 +319,13 @@ export class APIConstruct implements FW24Construct {
         if (this.fw24.useMultiStackSetup()) {
             paramsApi.deploy = false;
             delete paramsApi.deployOptions;
+        } else if (this.isNestedControllerDeployment()) {
+            // Nested-controller apps publish a single, explicit stage AFTER every nested stack is
+            // registered (see createSingleDeployment). Letting RestApi auto-deploy here would
+            // publish an early stage that misses late-registered nested routes (the "deploy twice"
+            // bug). We assign this.api.deploymentStage ourselves once the deployment exists.
+            paramsApi.deploy = false;
+            delete paramsApi.deployOptions;
         }
         this.logger.debug("Creating API Gateway... ");
         // get the main stack from the framework
@@ -290,8 +351,10 @@ export class APIConstruct implements FW24Construct {
             });
         }
 
-        // Set up usage plans if configured
-        if (this.apiConstructConfig.usagePlans?.length) {
+        // Set up usage plans if configured. Usage plans bind to this.api.deploymentStage; for
+        // nested-controller apps that stage does not exist yet (deploy:false), so we defer plan
+        // setup until after the single deployment creates the stage (see flushDeferredUsagePlans).
+        if (!this.isNestedControllerDeployment() && this.apiConstructConfig.usagePlans?.length) {
             for (const planConfig of this.apiConstructConfig.usagePlans) {
                 this.setupUsagePlan(planConfig);
             }
@@ -311,8 +374,35 @@ export class APIConstruct implements FW24Construct {
         this.logger.info(`API-gateway construct: ${this.name} has imported APIs: ${this.fw24.hasImportedAPI(this.name)}`);
         if (this.fw24.hasImportedAPI(this.name) && this.fw24.useMultiStackSetup()) {
             await this.createDeployments();
-        } else if (this.fw24.hasImportedAPI(this.name)) {
+        } else if (this.fw24.hasImportedAPI(this.name) || this.isNestedControllerDeployment()) {
             await this.createSingleDeployment();
+        }
+
+        // Usage plans were deferred for nested-controller apps until the stage exists; flush now.
+        this.flushDeferredUsagePlans();
+    }
+
+    /**
+     * Nested-controller layout: controllers live in nested stacks under a shared parent, so the API
+     * must publish a single explicit stage after all nested stacks register (not auto-deploy early).
+     * Mutually exclusive with multiStack (getStack forbids parentStackName under multiStack).
+     */
+    private isNestedControllerDeployment(): boolean {
+        return !!this.apiConstructConfig.controllerParentStackName && !this.fw24.useMultiStackSetup();
+    }
+
+    /** Set up usage plans deferred during a nested-controller deployment, once the stage exists. */
+    private flushDeferredUsagePlans(): void {
+        if (!this.isNestedControllerDeployment()) {
+            return;
+        }
+        if (this.apiConstructConfig.usagePlans?.length) {
+            for (const planConfig of this.apiConstructConfig.usagePlans) {
+                this.setupUsagePlan(planConfig);
+            }
+        }
+        if (this.deferredApiKeyPlanRequested) {
+            this.setupUsagePlan(undefined, true);
         }
     }
 
@@ -345,24 +435,30 @@ export class APIConstruct implements FW24Construct {
         // sets the default controllers directory if not defined
         const controllersDirectory = this.apiConstructConfig.controllersDirectory || "./src/controllers";
 
-        // register the controllers
-        await Helper.registerHandlers(controllersDirectory, this.registerController);
+        // Collect descriptors first so the 'auto' strategy can resolve shared-root owners from
+        // deployed state BEFORE any controller is registered (registration order stays irrelevant).
+        const collected: Array<{ descriptor: HandlerDescriptor; ownerModule?: IFw24Module }> = [];
+        await Helper.registerHandlers(controllersDirectory, (desc: HandlerDescriptor) => { collected.push({ descriptor: desc }); });
 
         if (this.fw24.hasModules()) {
             const modules = this.fw24.getModules();
             this.logger.debug("API-gateway stack: construct: app has modules ", Array.from(modules.keys()));
             for (const [ , module ] of modules) {
-                const basePath = module.getBasePath();
-
-                this.logger.debug("Load controllers from module base-path: ", basePath);
-
+                this.logger.debug("Load controllers from module base-path: ", module.getBasePath());
                 Helper.registerControllersFromModule(
                     module,
-                    (desc: HandlerDescriptor) => this.registerController(desc, module)
+                    (desc: HandlerDescriptor) => { collected.push({ descriptor: desc, ownerModule: module }); }
                 );
             }
         } else {
             this.logger.debug("API-gateway stack: construct: app has NO modules ");
+        }
+
+        // 'auto' strategy: discover which deployed stack currently owns each shared root.
+        await this.resolveAutoSharedRootOwners(collected.map((c) => c.descriptor));
+
+        for (const { descriptor, ownerModule } of collected) {
+            await this.registerController(descriptor, ownerModule);
         }
 
         // Register system controllers from fw24 singleton
@@ -502,9 +598,14 @@ export class APIConstruct implements FW24Construct {
 
         this.logger.debug(`Register Controller ~ Default Authorizer: name: ${defaultAuthorizerName} - type: ${defaultAuthorizerType} - groups: ${defaultAuthorizerGroups}`);
 
-        // Set up API key if required
+        // Set up API key if required. For nested-controller apps the deployment stage does not exist
+        // yet, so record the request and create the plan in flushDeferredUsagePlans (post-deployment).
         if (controllerConfig.requireApiKey) {
-            this.setupUsagePlan(undefined, true);
+            if (this.isNestedControllerDeployment()) {
+                this.deferredApiKeyPlanRequested = true;
+            } else {
+                this.setupUsagePlan(undefined, true);
+            }
         }
 
         // Set up routes for the controller
@@ -629,12 +730,27 @@ export class APIConstruct implements FW24Construct {
         // create the name from all the controller hash values combined as a single hash and add dependency on all the controllers
         const deploymentName = `deployment-${createHash('md5').update(Array.from(this.controllerStacks.values()).map(c => c.controllersHash).join('-')).digest('hex')}`;
 
+        const nestedControllerDeployment = this.isNestedControllerDeployment();
+        const deployOptions = this.apiConstructConfig.apiOptions?.deployOptions;
+
         const deployment = new Deployment(this.fw24.getStack(this.name), deploymentName, {
             api: this.api,
-            stageName: stageName,
+            description: deployOptions?.description,
+            // For nested-controller apps we publish the stage explicitly below (so it can depend on
+            // every nested stack and so this.api.deploymentStage gets set for usage plans). For the
+            // imported-API path, keep the original behaviour of letting Deployment create the stage.
+            ...(nestedControllerDeployment ? {} : { stageName }),
         });
 
-        for (const [ _controllerStackName, { methods, resources } ] of this.controllerStacks.entries()) {
+        for (const [ controllerStackName, { methods, resources } ] of this.controllerStacks.entries()) {
+            // The deployment must wait for every nested stack's resources/methods to exist, otherwise
+            // the published stage can miss late-registered routes (the "deploy twice" bug).
+            const controllerStack = this.fw24.getStack(controllerStackName);
+            if (controllerStack !== this.mainStack) {
+                this.logger.debug(`Adding nested stack dependency ${controllerStackName} to deployment`);
+                deployment.node.addDependency(controllerStack);
+            }
+
             for (const method of methods) {
                 this.logger.debug(`Adding method dependency ${method.httpMethod} ${method.resource.path} to deployment`);
                 deployment.node.addDependency(method)
@@ -644,6 +760,24 @@ export class APIConstruct implements FW24Construct {
                 this.logger.debug(`Adding resource dependency ${resource.path} to deployment`);
                 deployment.node.addDependency(resource);
             }
+        }
+
+        // Ensure main-stack-owned shared roots exist before the deployment publishes the stage.
+        // (Pinned roots live in nested stacks, already covered by the nested-stack dependency above.)
+        for (const { resource, ownerStack } of this.sharedControllerRoots.values()) {
+            if (ownerStack === this.mainStack) {
+                deployment.node.addDependency(resource);
+            }
+        }
+
+        if (nestedControllerDeployment) {
+            // Publish exactly one stage, wired to this deployment, and expose it as the API's
+            // deploymentStage so usage plans / api keys can bind to a real stage.
+            this.api.deploymentStage = new Stage(this.mainStack, `${this.fw24.appName}-${stageName}-stage`, {
+                ...(deployOptions ?? {}),
+                deployment,
+                stageName,
+            });
         }
     }
 
@@ -673,6 +807,151 @@ export class APIConstruct implements FW24Construct {
         return this.apiConstructConfig.cors || [];
     }
 
+    /** Route + stack name for a controller descriptor (mirrors registerController's derivation). */
+    private describeController(descriptor: HandlerDescriptor): { route: string; stackName: string } {
+        const { handlerClass, fileName } = descriptor;
+        const folderPath = fileName.split('/').slice(0, -1).join('/');
+        const handlerInstance = new handlerClass();
+        const route = fileName.includes('/') ? `${folderPath}/${handlerInstance.controllerName}` : handlerInstance.controllerName;
+        const stackName = handlerInstance?.controllerConfig?.stackName || route;
+        return { route, stackName };
+    }
+
+    /**
+     * 'auto' strategy: for each shared root, discover from deployed CloudFormation which controller
+     * stack currently owns it, and record that stack as the owner. The owning controller is matched
+     * by ROUTE (a semantic value present in both the deployed template and the app's controllers) —
+     * never by CloudFormation logical id (which is an unresolved token at synth) and with no hardcoded
+     * segment names. Fails loud rather than guessing; honours a `nestedControllerRootOwners` value as
+     * an explicit fallback for the unresolvable cases (no creds / ambiguous / unmatched).
+     */
+    private async resolveAutoSharedRootOwners(descriptors: HandlerDescriptor[]): Promise<void> {
+        if (this.apiConstructConfig.nestedControllerRootStrategy !== 'auto') {
+            return;
+        }
+
+        const routeToStackName = new Map<string, string>();
+        const rootsWithNestedControllers = new Set<string>();
+        for (const descriptor of descriptors) {
+            const { route, stackName } = this.describeController(descriptor);
+            routeToStackName.set(route, stackName);
+            const parts = route.split('/');
+            if (parts.length > 1) {
+                rootsWithNestedControllers.add(parts[ 0 ]);
+            }
+        }
+        if (rootsWithNestedControllers.size === 0) {
+            return;
+        }
+
+        const fallback = (rootSegment: string): string | undefined => this.apiConstructConfig.nestedControllerRootOwners?.[ rootSegment ];
+
+        let resolutions;
+        try {
+            const lookup = this.nestedRootLookup ?? createCloudFormationNestedRootLookup();
+            resolutions = await resolveDeployedNestedRootOwners(this.mainStack.stackName, [ ...rootsWithNestedControllers ], lookup);
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            // No silent guessing: every root either resolves, has an explicit fallback, or we fail loud.
+            const unresolved = [ ...rootsWithNestedControllers ].filter((root) => !fallback(root));
+            if (unresolved.length > 0) {
+                throw new Error(
+                    `nestedControllerRootStrategy 'auto' could not look up deployed shared-root owners on `
+                    + `${this.mainStack.stackName} (${message}). Run the build with AWS credentials, or set `
+                    + `nestedControllerRootOwners for: ${unresolved.join(', ')}, or use the 'pinned'/'main-stack' strategy.`,
+                );
+            }
+            for (const root of rootsWithNestedControllers) {
+                this.resolvedAutoRootOwners.set(root, fallback(root)!);
+            }
+            return;
+        }
+
+        for (const [ root, resolution ] of resolutions) {
+            if (resolution.kind === 'not-found') {
+                // greenfield root — nothing deployed owns it yet; main stack will create it
+                continue;
+            }
+            if (resolution.kind === 'ambiguous') {
+                const pinned = fallback(root);
+                if (pinned) {
+                    this.resolvedAutoRootOwners.set(root, pinned);
+                    continue;
+                }
+                throw new Error(
+                    `nestedControllerRootStrategy 'auto' found multiple deployed owners for /${root} `
+                    + `(${resolution.ownerStackLogicalIds.join(', ')}). Resolve the drift or set `
+                    + `nestedControllerRootOwners.${root}.`,
+                );
+            }
+            // owned: the owning controller is the deployed route that matches one of our controllers
+            const ownerRoute = resolution.candidateRoutes.find((candidate) => routeToStackName.has(candidate));
+            if (ownerRoute) {
+                this.resolvedAutoRootOwners.set(root, routeToStackName.get(ownerRoute)!);
+                this.logger.info(`Nested root /${root} resolved (auto) to existing owner stack ${routeToStackName.get(ownerRoute)}`);
+                continue;
+            }
+            const pinned = fallback(root);
+            if (pinned) {
+                this.resolvedAutoRootOwners.set(root, pinned);
+                continue;
+            }
+            throw new Error(
+                `nestedControllerRootStrategy 'auto' found /${root} deployed but could not match its owner to a `
+                + `current controller (deployed routes under /${root}: ${resolution.candidateRoutes.join(', ') || 'none'}). `
+                + `Set nestedControllerRootOwners.${root}.`,
+            );
+        }
+    }
+
+    /** Resolve the controller stack that should own a shared root, per the configured strategy. */
+    private resolveSharedRootOwnerStackName(rootSegment: string): string | undefined {
+        switch (this.apiConstructConfig.nestedControllerRootStrategy) {
+            case 'pinned':
+                return this.apiConstructConfig.nestedControllerRootOwners?.[ rootSegment ];
+            case 'auto':
+                return this.resolvedAutoRootOwners.get(rootSegment)
+                    ?? this.apiConstructConfig.nestedControllerRootOwners?.[ rootSegment ];
+            default:
+                return undefined; // 'main-stack'
+        }
+    }
+
+    /**
+     * Create (once) the shared root segment for a nested controller in its STABLE owner stack, and
+     * publish its resource-id token so sibling nested stacks can reference it. The owner is decided
+     * by the configured strategy (main stack, pinned, or auto-resolved) — never by registration
+     * order — so the segment's CloudFormation logical id is identical on every synth. That is what
+     * removes the 409/ordering bug.
+     */
+    private getOrCreateSharedControllerRoot(rootSegment: string): { resource: IResource; ownerStack: Stack } {
+        const existing = this.sharedControllerRoots.get(rootSegment);
+        if (existing) {
+            return existing;
+        }
+
+        const ownerStackName = this.resolveSharedRootOwnerStackName(rootSegment);
+
+        let resource: IResource;
+        let ownerStack: Stack;
+        if (ownerStackName) {
+            // pinned/auto: create the root in its existing owner stack — moves no live resource
+            this.fw24.getStack(ownerStackName, this.apiConstructConfig.controllerParentStackName);
+            ownerStack = this.fw24.getStack(ownerStackName);
+            resource = this.getAPI(ownerStackName).api.root.addResource(rootSegment);
+            this.logger.debug(`Shared root /${rootSegment} owned by existing controller stack ${ownerStackName}`);
+        } else {
+            // default ('main-stack'), or a greenfield root under 'auto': the main stack owns it
+            ownerStack = this.mainStack;
+            resource = this.api.root.addResource(rootSegment);
+        }
+
+        const entry = { resource, ownerStack };
+        this.sharedControllerRoots.set(rootSegment, entry);
+        this.fw24.setConstructOutput(this, `restAPI_controller_${rootSegment}`, resource, OutputType.RESOURCE, 'resourceId');
+        return entry;
+    }
+
     private readonly getOrCreateControllerResource = (controllerName: string, controllerStackName: string): IResource => {
         let restAPI = this.getAPI(controllerStackName);
         let controllerResource: IResource = restAPI.api.root;
@@ -680,16 +959,20 @@ export class APIConstruct implements FW24Construct {
         const pathParts = controllerName.split('/');
         for (const pathPart of pathParts) {
             let childResource = controllerResource.getResource(pathPart) as IResource;
-            // if it's a nested controller, the root resource may not be created in another stack
+            // The first path part of a nested controller (e.g. `internal` in `internal/notifications`)
+            // is a SHARED root owned by the main stack. Resolve it from there instead of letting
+            // whichever controller registers first create it — this is what removes the 409/ordering bug.
             const isNestedController = pathParts.length > 1;
             if (!childResource && isNestedController && pathPart === pathParts[ 0 ]) {
-                // try to get the root resource from the fw24 output
-                this.logger.debug(`Getting controller resource for ${pathPart} from fw24 output`);
-                const controllerResourceId = this.fw24.getEnvironmentVariable(`restAPI_controller_${pathPart}_resourceId`, 'resource', currentStack);
-                if (controllerResourceId) {
-                    this.logger.debug(`Controller resource for ${pathPart} found in fw24 output: ${controllerResourceId}`);
+                const sharedRoot = this.getOrCreateSharedControllerRoot(pathPart);
+                if (currentStack === sharedRoot.ownerStack) {
+                    // same stack as the owner (single-stack app, or this controller IS the owner) — use it directly
+                    childResource = sharedRoot.resource;
+                } else {
+                    // reference the owner stack's root by its resource-id token; CDK wires it across stacks
+                    this.logger.debug(`Referencing shared root /${pathPart} (owner ${sharedRoot.ownerStack.stackName}) from ${controllerStackName}`);
                     childResource = Resource.fromResourceAttributes(currentStack, `${this.fw24.appName}-${controllerStackName}-${pathPart}`, {
-                        resourceId: controllerResourceId,
+                        resourceId: sharedRoot.resource.resourceId,
                         restApi: restAPI.api,
                         path: '/' + pathPart
                     });
@@ -702,10 +985,6 @@ export class APIConstruct implements FW24Construct {
                 if (restAPI.isImported) {
                     const corsPreflightMethod = childResource.addCorsPreflight(this.getCorsPreflightOptions());
                     this.methods.push(corsPreflightMethod);
-                }
-                if (isNestedController && pathPart === pathParts[ 0 ]) {
-                    this.logger.debug(`Setting output for contorller resource ${controllerStackName} path ${pathPart}`);
-                    this.fw24.setConstructOutput(this, `restAPI_controller_${pathPart}`, childResource, OutputType.RESOURCE, 'resourceId');
                 }
             }
             controllerResource = childResource;

--- a/src/constructs/nested-controller-root-lookup.test.ts
+++ b/src/constructs/nested-controller-root-lookup.test.ts
@@ -1,0 +1,95 @@
+import {
+    controllerRoutePathsUnderRoot,
+    NestedRootCloudFormationLookup,
+    resolveDeployedNestedRootOwners,
+    templateOwnsNestedRoot,
+} from './nested-controller-root-lookup';
+
+// A nested stack template for the `internal/team` controller: it owns /internal (child of API root)
+// and declares its own /internal/team + a /internal/team/ping route under it.
+const teamOwnerTemplate = {
+    Resources: {
+        InternalRoot: {
+            Type: 'AWS::ApiGateway::Resource',
+            Properties: { PathPart: 'internal', ParentId: { 'Fn::GetAtt': [ 'restApi', 'RootResourceId' ] } },
+        },
+        TeamSeg: {
+            Type: 'AWS::ApiGateway::Resource',
+            Properties: { PathPart: 'team', ParentId: { Ref: 'InternalRoot' } },
+        },
+        PingSeg: {
+            Type: 'AWS::ApiGateway::Resource',
+            Properties: { PathPart: 'ping', ParentId: { Ref: 'TeamSeg' } },
+        },
+        Method: { Type: 'AWS::ApiGateway::Method', Properties: {} },
+    },
+};
+
+// A sibling stack that only references /internal (does not own it) and adds its own leaf.
+const notificationsSiblingTemplate = {
+    Resources: {
+        NotifSeg: {
+            Type: 'AWS::ApiGateway::Resource',
+            Properties: { PathPart: 'notifications', ParentId: { Ref: 'someImportedInternalId' } },
+        },
+    },
+};
+
+describe('templateOwnsNestedRoot', () => {
+    it('true when the segment is a child of the API root', () => {
+        expect(templateOwnsNestedRoot(teamOwnerTemplate, 'internal')).toBe(true);
+    });
+    it('false when the segment is not present as a root child', () => {
+        expect(templateOwnsNestedRoot(notificationsSiblingTemplate, 'internal')).toBe(false);
+    });
+    it('generic for any segment name and safe on malformed input', () => {
+        expect(templateOwnsNestedRoot({ Resources: { R: { Type: 'AWS::ApiGateway::Resource', Properties: { PathPart: 'webhooks', ParentId: { Ref: 'apiRootResourceId' } } } } }, 'webhooks')).toBe(true);
+        expect(templateOwnsNestedRoot(undefined, 'internal')).toBe(false);
+    });
+});
+
+describe('controllerRoutePathsUnderRoot', () => {
+    it('returns every full route path under the owned root (no hardcoded names)', () => {
+        expect(controllerRoutePathsUnderRoot(teamOwnerTemplate, 'internal')).toEqual([ 'internal/team', 'internal/team/ping' ]);
+    });
+    it('returns [] when the template does not own the root', () => {
+        expect(controllerRoutePathsUnderRoot(notificationsSiblingTemplate, 'internal')).toEqual([]);
+    });
+});
+
+describe('resolveDeployedNestedRootOwners', () => {
+    const lookupFrom = (stacks: Array<{ logicalId: string; physicalId: string; template: unknown }>): NestedRootCloudFormationLookup => ({
+        listNestedStacks: async () => stacks.map(({ logicalId, physicalId }) => ({ logicalId, physicalId })),
+        getTemplate: async (id) => stacks.find((s) => s.physicalId === id)?.template ?? {},
+    });
+
+    it('returns the candidate routes from the single owning stack', async () => {
+        const lookup = lookupFrom([
+            { logicalId: 'teamNS', physicalId: 'arn:team', template: teamOwnerTemplate },
+            { logicalId: 'notifNS', physicalId: 'arn:notif', template: notificationsSiblingTemplate },
+        ]);
+        const result = await resolveDeployedNestedRootOwners('app-main', [ 'internal' ], lookup);
+        expect(result.get('internal')).toEqual({ kind: 'owned', candidateRoutes: [ 'internal/team', 'internal/team/ping' ] });
+    });
+
+    it('not-found for a greenfield root no deployed stack owns', async () => {
+        const lookup = lookupFrom([ { logicalId: 'teamNS', physicalId: 'arn:team', template: teamOwnerTemplate } ]);
+        expect((await resolveDeployedNestedRootOwners('m', [ 'webhooks' ], lookup)).get('webhooks')).toEqual({ kind: 'not-found' });
+    });
+
+    it('ambiguous when two stacks both own the root (dirty/mid-move state)', async () => {
+        const lookup = lookupFrom([
+            { logicalId: 'aNS', physicalId: 'arn:a', template: teamOwnerTemplate },
+            { logicalId: 'bNS', physicalId: 'arn:b', template: teamOwnerTemplate },
+        ]);
+        expect((await resolveDeployedNestedRootOwners('m', [ 'internal' ], lookup)).get('internal')).toEqual({ kind: 'ambiguous', ownerStackLogicalIds: [ 'aNS', 'bNS' ] });
+    });
+
+    it('propagates lookup failures so the caller can fail loud', async () => {
+        const failing: NestedRootCloudFormationLookup = {
+            listNestedStacks: async () => { throw new Error('no credentials'); },
+            getTemplate: async () => ({}),
+        };
+        await expect(resolveDeployedNestedRootOwners('m', [ 'internal' ], failing)).rejects.toThrow('no credentials');
+    });
+});

--- a/src/constructs/nested-controller-root-lookup.ts
+++ b/src/constructs/nested-controller-root-lookup.ts
@@ -1,0 +1,189 @@
+import { CloudFormationClient, GetTemplateCommand, ListStackResourcesCommand } from '@aws-sdk/client-cloudformation';
+import { createLogger } from '../logging';
+
+const logger = createLogger('nested-controller-root-lookup');
+
+/**
+ * Minimal CloudFormation surface needed to resolve which deployed stack currently owns a shared
+ * nested-controller root segment. Abstracted behind an interface so it can be mocked in tests and
+ * so the strategy code never talks to the AWS SDK directly.
+ */
+export interface NestedRootCloudFormationLookup {
+    /** List nested stacks (AWS::CloudFormation::Stack) directly under the given parent stack. */
+    listNestedStacks(parentStackName: string): Promise<Array<{ logicalId: string; physicalId: string }>>;
+    /** Fetch a stack's processed template body (parsed JSON). */
+    getTemplate(stackId: string): Promise<unknown>;
+}
+
+/**
+ * Resolution of a single shared root's deployed owner. `candidateRoutes` are the controller route
+ * paths (e.g. `internal/team`, `internal/team/ping`) found in the owner stack's template — the
+ * caller intersects them with the app's actual controller routes to identify the owning controller
+ * stack. No logical-id matching, no hardcoded segment names.
+ */
+export type NestedRootOwnerResolution =
+    | { kind: 'owned'; candidateRoutes: string[] }
+    | { kind: 'not-found' }
+    | { kind: 'ambiguous'; ownerStackLogicalIds: string[] };
+
+type CfnResource = { Type?: string; Properties?: { PathPart?: string; ParentId?: unknown } };
+
+/** Extract the parent reference of an API Gateway resource as either a logical id, or `ROOT`. */
+function parentKey(parentId: unknown): string | undefined {
+    if (!parentId || typeof parentId !== 'object') {
+        return undefined;
+    }
+    const obj = parentId as Record<string, unknown>;
+    if ('Fn::GetAtt' in obj && Array.isArray(obj[ 'Fn::GetAtt' ])) {
+        const [ , attr ] = obj[ 'Fn::GetAtt' ] as unknown[];
+        return String(attr).includes('RootResourceId') ? 'ROOT' : undefined;
+    }
+    if ('Ref' in obj) {
+        const ref = String(obj.Ref);
+        return ref.includes('RootResourceId') ? 'ROOT' : ref;
+    }
+    return undefined;
+}
+
+/**
+ * Pure: does this template declare `rootSegment` as a direct child of the REST API root? Generic —
+ * works for any segment name.
+ */
+export function templateOwnsNestedRoot(templateBody: unknown, rootSegment: string): boolean {
+    const resources = (templateBody as { Resources?: Record<string, CfnResource> })?.Resources ?? {};
+    for (const resource of Object.values(resources)) {
+        if (resource.Type === 'AWS::ApiGateway::Resource'
+            && resource.Properties?.PathPart === rootSegment
+            && parentKey(resource.Properties.ParentId) === 'ROOT') {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * Pure: walk the API Gateway resource tree in this template starting at `rootSegment` (which must be
+ * a child of the API root) and return every full path under it, e.g. for an `internal/team`
+ * controller: `['internal/team', 'internal/team/ping']`. These are candidate controller routes; the
+ * caller matches them against the app's real controllers. Returns `[]` if the template does not own
+ * the root. No hardcoded segment names — every part comes from `PathPart`.
+ */
+export function controllerRoutePathsUnderRoot(templateBody: unknown, rootSegment: string): string[] {
+    const resources = (templateBody as { Resources?: Record<string, CfnResource> })?.Resources ?? {};
+
+    // logicalId -> { pathPart, parent } for every API Gateway resource
+    const nodes = new Map<string, { pathPart: string; parent: string | undefined }>();
+    for (const [ logicalId, resource ] of Object.entries(resources)) {
+        if (resource.Type === 'AWS::ApiGateway::Resource' && typeof resource.Properties?.PathPart === 'string') {
+            nodes.set(logicalId, { pathPart: resource.Properties.PathPart, parent: parentKey(resource.Properties.ParentId) });
+        }
+    }
+
+    // find the root-segment resource (child of API root with matching PathPart)
+    let rootLogicalId: string | undefined;
+    for (const [ logicalId, node ] of nodes) {
+        if (node.parent === 'ROOT' && node.pathPart === rootSegment) {
+            rootLogicalId = logicalId;
+            break;
+        }
+    }
+    if (!rootLogicalId) {
+        return [];
+    }
+
+    const childrenOf = new Map<string, string[]>();
+    for (const [ logicalId, node ] of nodes) {
+        if (node.parent) {
+            const list = childrenOf.get(node.parent) ?? [];
+            list.push(logicalId);
+            childrenOf.set(node.parent, list);
+        }
+    }
+
+    const paths: string[] = [];
+    const walk = (logicalId: string, prefix: string) => {
+        for (const childId of childrenOf.get(logicalId) ?? []) {
+            const childPath = `${prefix}/${nodes.get(childId)!.pathPart}`;
+            paths.push(childPath);
+            walk(childId, childPath);
+        }
+    };
+    walk(rootLogicalId, rootSegment);
+    return paths;
+}
+
+/**
+ * For each requested root segment, resolve its deployed owner stack and return the candidate
+ * controller routes found in that stack's template. Throws on lookup failure (e.g. missing
+ * credentials) so the caller can FAIL LOUD rather than silently guessing.
+ */
+export async function resolveDeployedNestedRootOwners(
+    parentStackName: string,
+    rootSegments: string[],
+    lookup: NestedRootCloudFormationLookup,
+): Promise<Map<string, NestedRootOwnerResolution>> {
+    const result = new Map<string, NestedRootOwnerResolution>();
+    if (rootSegments.length === 0) {
+        return result;
+    }
+
+    const nestedStacks = await lookup.listNestedStacks(parentStackName);
+
+    // for each root: which nested stacks own it, and the routes inside the owning template
+    const ownersByRoot = new Map<string, Array<{ logicalId: string; routes: string[] }>>();
+    for (const segment of rootSegments) {
+        ownersByRoot.set(segment, []);
+    }
+
+    for (const nested of nestedStacks) {
+        const template = await lookup.getTemplate(nested.physicalId);
+        for (const segment of rootSegments) {
+            if (templateOwnsNestedRoot(template, segment)) {
+                ownersByRoot.get(segment)!.push({ logicalId: nested.logicalId, routes: controllerRoutePathsUnderRoot(template, segment) });
+            }
+        }
+    }
+
+    for (const segment of rootSegments) {
+        const owners = ownersByRoot.get(segment)!;
+        if (owners.length === 0) {
+            result.set(segment, { kind: 'not-found' });
+        } else if (owners.length === 1) {
+            result.set(segment, { kind: 'owned', candidateRoutes: owners[ 0 ].routes });
+        } else {
+            logger.warn(`Shared root /${segment} is declared by multiple deployed stacks: ${owners.map((o) => o.logicalId).join(', ')}`);
+            result.set(segment, { kind: 'ambiguous', ownerStackLogicalIds: owners.map((o) => o.logicalId) });
+        }
+    }
+
+    return result;
+}
+
+/** Default AWS-backed lookup. Uses ambient credentials/region (present in CI/CD deploy). */
+export function createCloudFormationNestedRootLookup(): NestedRootCloudFormationLookup {
+    const client = new CloudFormationClient({});
+    return {
+        async listNestedStacks(parentStackName: string) {
+            const out: Array<{ logicalId: string; physicalId: string }> = [];
+            const response = await client.send(new ListStackResourcesCommand({ StackName: parentStackName }));
+            for (const summary of response.StackResourceSummaries ?? []) {
+                if (summary.ResourceType === 'AWS::CloudFormation::Stack' && summary.LogicalResourceId && summary.PhysicalResourceId) {
+                    out.push({ logicalId: summary.LogicalResourceId, physicalId: summary.PhysicalResourceId });
+                }
+            }
+            return out;
+        },
+        async getTemplate(stackId: string) {
+            const response = await client.send(new GetTemplateCommand({ StackName: stackId }));
+            const body = response.TemplateBody;
+            if (typeof body === 'string') {
+                try {
+                    return JSON.parse(body);
+                } catch {
+                    return {};
+                }
+            }
+            return body ?? {};
+        },
+    };
+}


### PR DESCRIPTION
## Problem

Controllers nested under a shared folder (e.g. `controllers/internal/*`) each deploy in their own CloudFormation nested stack, but they all serve routes under a shared path segment (`/internal`). That segment is a single `AWS::ApiGateway::Resource` that can only be **created** in one stack and must be **referenced** by every sibling.

The previous logic chose the owner of that shared segment by controller **registration (filename) order**. As a result:

- **`409 AlreadyExists`** — adding a new controller that sorts before the historical owner (or adding several siblings at once) made a different stack try to create `/internal`, which already existed elsewhere.
- **Stale stage / "deploy twice"** — the REST API auto-published a stage before late-registered nested-stack routes existed, so some routes returned 403 until a second deploy.

## Root cause

Ownership of the shared segment was **unstable across deploys** — it moved with filename order. Every failure above follows from that.

## Approach

Decide the owner of each shared root **up front** (never by registration order), create it once there, and have every sibling reference it via the segment's resource-id token. The segment's CloudFormation logical id is then identical on every synth.

Ownership is selected with `nestedControllerRootStrategy` (no hardcoded segment names in any strategy):

| Strategy | Owner decided by | Build needs AWS creds? | Best for |
|----------|------------------|------------------------|----------|
| `'main-stack'` *(default)* | code — the main RestApi stack | no | new apps (zero config) |
| `'pinned'` | `nestedControllerRootOwners` config | no | already-deployed apps; explicit & offline |
| `'auto'` | looked up from deployed CloudFormation, matched by route | yes (present in CI/CD deploy) | already-deployed apps; hands-off |

- **`'main-stack'`** — the main stack owns every shared root. Fully deterministic and offline; new apps need no configuration and can add controllers in any order.
- **`'pinned'`** — the root stays in the controller stack that already owns it, named in config. Moves no live resource; deterministic and offline.
- **`'auto'`** — at build time it reads the deployed stacks, finds which stack currently owns each root by **walking the template and matching routes** (a value present in both the deployed template and the app's controllers — not CloudFormation logical ids, which are unresolved tokens at synth), and keeps the root there. No configuration and moves no live resource. It **fails loud** rather than guessing when it can't reach AWS or finds an ambiguous state; a `nestedControllerRootOwners` entry serves as an explicit fallback for those cases.

### Single deployment / stage fix

Nested-controller apps now create the REST API with `deploy: false` and publish exactly one `Deployment` plus one `Stage` after every nested stack is registered (the deployment depends on each nested stack). The stage is assigned to `api.deploymentStage` so usage plans bind to a real stage.

## Migrating an already-deployed app

An app already deployed with a root in a nested stack can either keep it there (`'pinned'`/`'auto'`) or move it into the main stack once per environment with `cdk refactor` to reach the zero-config `'main-stack'` end state. Full guidance: `docs/nested-controller-shared-roots.md`.

## Dependencies

Adds `@aws-sdk/client-cloudformation`, used only by the `'auto'` strategy's lookup.

## Testing

- Unit tests for the deployed-state lookup: route extraction from a template, owner resolution, ambiguity detection, and fail-on-error (no silent guessing).
- Construct tests on synthesized templates: order independence (the shared root's logical id is identical across registration orders and when a new earlier-sorting sibling is added), generic root names, single Deployment + single Stage, usage plans bound to a real stage, and `'pinned'`/`'auto'` keeping the root in its existing owner stack even when a non-owner registers first.
- All existing API construct tests pass unchanged (no snapshot drift).

## Note

The `'auto'` strategy's CloudFormation lookup is covered by mocked tests. Validate it against a non-production environment before relying on it in production. The `'main-stack'` and `'pinned'` strategies and the single-deployment/stage fix are verified against synthesized output.

## Supersedes

Replaces the earlier attempts #263 (deploy-time resource-deletion handler) and #289 (synthesis-time CloudFormation introspection).
