### PR TITLE
fix(queue): wire EMAIL_QUEUE_URL on queue workers by default

### DIFF
--- a/src/constructs/queue.ts
+++ b/src/constructs/queue.ts
@@ -10,6 +10,7 @@ import { QueueLambda } from "./queue-lambda";
 import { ILambdaEnvConfig } from "../interfaces/lambda-env";
 import { LogDuration, createLogger } from "../logging";
 import { DynamoDBConstruct } from "./dynamodb";
+import { MailerConstruct } from "./mailer";
 import { NodejsFunction, NodejsFunctionProps } from "aws-cdk-lib/aws-lambda-nodejs";
 import { IConstructConfig } from "../interfaces/construct-config";
 import { LayerConstruct } from "./layer";
@@ -73,7 +74,7 @@ export class QueueConstruct implements FW24Construct {
     readonly fw24: Fw24 = Fw24.getInstance();
 
     name: string = QueueConstruct.name;
-    dependencies: string[] = [ DynamoDBConstruct.name, VpcConstruct.name, LayerConstruct.name ];
+    dependencies: string[] = [ DynamoDBConstruct.name, VpcConstruct.name, LayerConstruct.name, MailerConstruct.name ];
     output!: FW24ConstructOutput;
 
     mainStack!: Stack;
@@ -219,6 +220,7 @@ export class QueueConstruct implements FW24Construct {
             entry: queueInfo.filePath + "/" + queueInfo.fileName,
             environmentVariables: this.fw24.resolveEnvVariables(queueConfig.env),
             resourceAccess: queueConfig?.resourceAccess,
+            allowSendEmail: queueConfig?.allowSendEmail !== false,
             functionTimeout: queueConfig?.functionTimeout || this.fw24.getConfig().functionTimeout,
             policies: queueConfig?.policies,
             functionProps: merge([

--- a/src/decorators/queue.ts
+++ b/src/decorators/queue.ts
@@ -74,6 +74,13 @@ export type IQueueConfig = CommonLambdaHandlerOptions & {
 	manualRegistration?: boolean;
 
 	/**
+	 * When true (default) and the app uses MailerConstruct, the queue worker gets EMAIL_QUEUE_URL
+	 * and permission to enqueue mail jobs (same as API controllers and scheduled tasks).
+	 * Set false only when the handler must not send email.
+	 */
+	allowSendEmail?: boolean;
+
+	/**
 	 * Observability configuration for the queue handler.
 	 * Allows specifying custom tags, source, and attributes for spans.
 	 * 


### PR DESCRIPTION
## Problem

API controllers and scheduled tasks already pass `allowSendEmail: true` into `LambdaFunction`, which sets `EMAIL_QUEUE_URL` and grants `sqs:SendMessage` on the mail queue when the app uses `MailerConstruct`. Queue workers did not — `QueueConstruct.createQueueLambda` never forwarded that flag.

Any queue handler that calls `sendMail()` or enqueues to the mail queue at runtime therefore saw an empty `EMAIL_QUEUE_URL`. This surfaced in plusfan-trials-backend when bulk notification sends moved to a `notification-fanout` SQS worker: the API returned "Queued" while the worker skipped email with "email queue not configured".

## Intent

Queue workers that send email should get the same mail-queue env and IAM as API Lambdas and scheduled tasks, without each app listing `emailQueue` in `resourceAccess.queues` as a workaround.

## Approach

- Default `allowSendEmail` to **true** for queue workers (same default posture as API/scheduler).
- Pass `allowSendEmail: queueConfig?.allowSendEmail !== false` into `LambdaFunction`, reusing the existing block in `lambda-function.ts` that sets `EMAIL_QUEUE_URL`.
- Add `MailerConstruct` to `QueueConstruct.dependencies` so `emailQueue_queueName` is registered before queue Lambdas are synthesized.
- Expose optional `allowSendEmail?: boolean` on `@Queue` config; set `false` only when a handler must not enqueue mail.

## Solution

- **`src/constructs/queue.ts`** — Mailer dependency + forward `allowSendEmail` to `LambdaFunction`.
- **`src/decorators/queue.ts`** — document `allowSendEmail` on `IQueueConfig`.

No change to `lambda-function.ts`; the single wiring point stays as-is. `dist/` is updated by the release CI after merge.

## Behaviour / features

| Lambda kind | Before | After |
|-------------|--------|-------|
| API controller | `EMAIL_QUEUE_URL` when `MailerConstruct` used | unchanged |
| Scheduled task | `EMAIL_QUEUE_URL` when `MailerConstruct` used | unchanged |
| Queue worker | no `EMAIL_QUEUE_URL` unless `resourceAccess.queues: ['emailQueue']` | `EMAIL_QUEUE_URL` by default; opt out with `allowSendEmail: false` |

When `allowSendEmail` is true and `fw24.emailProvider` is `MailerConstruct`, the worker receives `EMAIL_QUEUE_URL` and send permission on `emailQueue`.

## Configuration / environment

No new env vars. Opt out per queue:

```ts
@Queue('my-queue', { allowSendEmail: false })
```

## Deploy / dependencies

- Merge to `develop` → release tag (e.g. `v1.1.0-beta.40`); CI rebuilds `dist/`.
- Consumer apps (e.g. plusfan-trials-backend) bump `@ten24group/fw24` and redeploy.
- After bump, apps can remove `queues: ['emailQueue']` from queue `resourceAccess` and any `Environment.queueUrl('emailQueue')` fallback in dispatch code.

**Related:** ten24group/plusfan-trials-backend#149 (hotfix on `main` using the `resourceAccess` workaround until this ships).

## Test plan

- [ ] `npm run build` passes
- [ ] Synth a test app with `MailerConstruct` + a `@Queue` handler that calls `sendMail()` — worker Lambda env includes `EMAIL_QUEUE_URL`
- [ ] Synth with `allowSendEmail: false` on a queue — worker env does **not** include `EMAIL_QUEUE_URL`
- [ ] Bump fw24 in trials-backend, remove `queues: ['emailQueue']` from `notification-fanout`, deploy to staging — bulk email delivery succeeds

## Known limitations

- `SchedulerConstruct` still does not declare `MailerConstruct` as a dependency (pre-existing). Scheduler tasks already pass `allowSendEmail: true` but only wait on Vpc/Layer; ordering has been fine in practice because scheduler tasks rarely send mail directly. Can be hardened in a follow-up.