### PR TITLE
fix(client): cap AWS SDK userAgentAppId to silence >50-char powertools warning

### DIFF
--- a/src/client/s3.ts
+++ b/src/client/s3.ts
@@ -3,9 +3,11 @@ import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { Command } from "@smithy/smithy-client";
 import { MetadataBearer, RequestPresigningArguments } from "@smithy/types";
 import { SpanObserver } from '../observability/observers/span';
+import { FW24_UA_APP_ID } from './user-agent';
 
 
 export const defaultS3Client = new S3Client({
+    userAgentAppId: FW24_UA_APP_ID,
     requestChecksumCalculation: "WHEN_REQUIRED",
     responseChecksumValidation: "WHEN_REQUIRED"
 });

--- a/src/client/sns.ts
+++ b/src/client/sns.ts
@@ -1,8 +1,9 @@
 import { SNSClient, PublishCommand, PublishBatchCommand, PublishBatchRequestEntry, MessageAttributeValue } from '@aws-sdk/client-sns';
 import { ExecutionContextData } from '../core/runtime/execution-context';
 import { getSnsTraceAttributes } from './util';
+import { FW24_UA_APP_ID } from './user-agent';
 
-const snsClient = new SNSClient({});
+const snsClient = new SNSClient({ userAgentAppId: FW24_UA_APP_ID });
 
 /**
  * Common message properties for FIFO topics and attributes

--- a/src/client/sqs.ts
+++ b/src/client/sqs.ts
@@ -1,6 +1,7 @@
 import { GetQueueAttributesCommand, SQSClient, SendMessageCommand, SendMessageCommandInput, MessageAttributeValue, SendMessageBatchCommand, SendMessageBatchRequestEntry } from '@aws-sdk/client-sqs';
 import { ExecutionContextData } from '../core/runtime/execution-context';
 import { getSqsTraceAttributes } from './util';
+import { FW24_UA_APP_ID } from './user-agent';
 
 /**
  * Lazily-created SQS client.
@@ -21,7 +22,9 @@ function getSqsClient(): SQSClient {
     const endpoint = process.env.AWS_ENDPOINT_URL_SQS?.trim() || undefined;
     if (sqsClient && sqsClientEndpoint === endpoint) return sqsClient;
     sqsClientEndpoint = endpoint;
-    sqsClient = endpoint ? new SQSClient({ endpoint }) : new SQSClient({});
+    sqsClient = endpoint
+        ? new SQSClient({ endpoint, userAgentAppId: FW24_UA_APP_ID })
+        : new SQSClient({ userAgentAppId: FW24_UA_APP_ID });
 
     return sqsClient;
 }

--- a/src/client/user-agent.ts
+++ b/src/client/user-agent.ts
@@ -1,0 +1,13 @@
+/**
+ * A short, stable `userAgentAppId` applied to every fw24-created AWS SDK client.
+ *
+ * Why this exists: `@aws-lambda-powertools/commons` (pulled in by `@aws-lambda-powertools/logger`
+ * and `/metrics`) sets `process.env.AWS_SDK_UA_APP_ID` at import time to
+ * `PT/NO-OP/<ver>/PTEnv/<AWS_EXECUTION_ENV>` (and appends if already set). That value exceeds the
+ * AWS SDK v3 limit of 50 characters, so every SDK client logs:
+ *   "The provided userAgentAppId exceeds the maximum length of 50 characters."
+ * Passing an explicit `userAgentAppId` on the client config takes precedence over the env value
+ * (`config?.userAgentAppId ?? loadConfig(NODE_APP_ID_CONFIG_OPTIONS)`), so a short valid tag here
+ * both silences the warning and keeps a meaningful attribution. Keep it <= 50 chars.
+ */
+export const FW24_UA_APP_ID = 'fw24';

--- a/src/core/runtime/mail-processor.ts
+++ b/src/core/runtime/mail-processor.ts
@@ -3,6 +3,7 @@ import type { SQSBatchItemFailure, SQSBatchResponse, SQSEvent, Context } from 'a
 import { QueueController, QueueProcessResult, QueueExecutionContext } from './sqs-controller';
 import { extractFromSqs, runWithExecutionContext, createExecutionContext } from './execution-context';
 import { SpanObserver } from '../../observability';
+import { FW24_UA_APP_ID } from '../../client/user-agent';
 
 /**
  * Email message structure sent via SQS
@@ -46,7 +47,7 @@ export class MailProcessor extends QueueController {
         super();
         // Initialize SES client once per Lambda container
         // Reused across warm starts for better performance
-        this.sesClient = new SESv2Client();
+        this.sesClient = new SESv2Client({ userAgentAppId: FW24_UA_APP_ID });
     }
 
     protected async initialize(_event: SQSEvent, _context: Context): Promise<void> {

--- a/src/observability/storage/service.ts
+++ b/src/observability/storage/service.ts
@@ -7,6 +7,7 @@
 
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import { FW24_UA_APP_ID } from '../../client/user-agent';
 import { Service } from '../../decorators';
 import { DIContainer, InjectConfig, InjectContainer, InjectEntitySchema } from '../../di';
 import { BaseEntityService } from '../../entity/base-service';
@@ -69,7 +70,7 @@ export class ObservabilityLogService extends BaseEntityService<ObservabilityLogS
     @InjectContainer()
     readonly container: IDIContainer
   ) {
-    const client = new DynamoDBClient({});
+    const client = new DynamoDBClient({ userAgentAppId: FW24_UA_APP_ID });
     const docClient = DynamoDBDocumentClient.from(client, {
       marshallOptions: { removeUndefinedValues: true, convertEmptyValues: true },
     });


### PR DESCRIPTION
## Problem
Every fw24 Lambda logs a noisy AWS SDK v3 warning:
> `The provided userAgentAppId exceeds the maximum length of 50 characters.`

## Root cause
`@aws-lambda-powertools/commons` (pulled in by `@aws-lambda-powertools/logger` + `/metrics`) sets `process.env.AWS_SDK_UA_APP_ID` **at import time** to `PT/NO-OP/<ver>/PTEnv/<AWS_EXECUTION_ENV>` (and *appends* if already set). The resulting value exceeds the AWS SDK v3 `userAgentAppId` limit of 50 chars, so `@aws-sdk/middleware-user-agent` logs the warning on every SDK client. It's not in any static Lambda env or first-party code — it's a Powertools side effect.

## Fix
Pass an explicit short `userAgentAppId` (`'fw24'`, new shared const in `src/client/user-agent.ts`) on all fw24-created SDK clients:
- `src/client/sns.ts` (SNSClient)
- `src/client/sqs.ts` (SQSClient)
- `src/client/s3.ts` (S3Client)
- `src/observability/storage/service.ts` (DynamoDBClient)
- `src/core/runtime/mail-processor.ts` (SESv2Client)

Explicit client config takes precedence over the env value (`config?.userAgentAppId ?? loadConfig(...)`), so this silences the warning and keeps a valid, meaningful UA tag. Ordering-immune (unlike an env sanitize).

## Verification
Empirically confirmed against the installed SDK: with the long powertools env set, a default client warns (appId len 87); a client with `userAgentAppId: 'fw24'` resolves to `"fw24"` with no warning. `tsc` clean.

## Notes
- Behavior-only for the UA header tag; no functional change to any AWS call.
- `dist` intentionally not rebuilt here (synced at release, per convention).