### PR TITLE
feat(constructs): LogForwarderConstruct — Lambda log shipping to Vector/Logtrail

### DIFF
--- a/src/constructs/index.ts
+++ b/src/constructs/index.ts
@@ -4,6 +4,7 @@ export * from './bucket';
 export * from './dynamodb';
 export * from './layer';
 export * from './di-layer';
+export * from './log-forwarder';
 export * from './fargate';
 export * from './ec2';
 export * from './mailer';

--- a/src/constructs/log-forwarder.test.ts
+++ b/src/constructs/log-forwarder.test.ts
@@ -1,0 +1,129 @@
+import { App, Stack, NestedStack } from 'aws-cdk-lib';
+import { Template, Match } from 'aws-cdk-lib/assertions';
+import { Function as LambdaFunction, Runtime, Code } from 'aws-cdk-lib/aws-lambda';
+import { Fw24 } from '../core/fw24';
+import { LogForwarderConstruct, DEFAULT_LOG_NOISE_RULES } from './log-forwarder';
+
+/**
+ * Unit tests for LogForwarderConstruct — verify the emitted CloudFormation without needing AWS creds:
+ * a forwarder Lambda is created, every OTHER function gets a subscription filter (the forwarder never
+ * subscribes itself), a single wildcard invoke permission is added, and the app-level noise rules are
+ * injected into the forwarder's environment.
+ */
+function makeStack(): { app: App; stack: Stack } {
+	(Fw24 as any).instance = undefined;
+	const app = new App();
+	const stack = new Stack(app, 'TestStack', { env: { account: '123456789012', region: 'us-east-1' } });
+	const fw24 = Fw24.getInstance();
+	fw24.setApp(app);
+	fw24.setConfig({ name: 'test-app', region: 'us-east-1', account: '123456789012' });
+	fw24.addStack('main', stack);
+	return { app, stack };
+}
+
+function dummyFn(stack: Stack, id: string): LambdaFunction {
+	return new LambdaFunction(stack, id, {
+		runtime: Runtime.NODEJS_22_X,
+		handler: 'index.handler',
+		code: Code.fromInline('exports.handler = async () => {};'),
+	});
+}
+
+/** Pull the forwarder function's environment out of a synthesized template. */
+function forwarderEnv(template: Template, ingestUrl: string): Record<string, string> {
+	const fns = template.findResources('AWS::Lambda::Function');
+	const match = Object.values(fns)
+		.map((f: any) => f.Properties?.Environment?.Variables)
+		.find((v: any) => v && v.FORWARDER_INGEST_URL === ingestUrl);
+	if (!match) throw new Error('forwarder function not found in template');
+	return match as Record<string, string>;
+}
+
+describe('LogForwarderConstruct', () => {
+	afterEach(() => {
+		(Fw24 as any).instance = undefined;
+	});
+
+	it('creates a forwarder and subscribes every other function (never itself)', async () => {
+		const { stack } = makeStack();
+		dummyFn(stack, 'AlphaFn');
+		dummyFn(stack, 'BetaFn');
+
+		await new LogForwarderConstruct({
+			stackName: 'main',
+			ingestHttpUrl: 'http://ingest.example/',
+			service: 'svc',
+			env: 'test',
+		}).construct();
+
+		const t = Template.fromStack(stack);
+		// Alpha + Beta get a subscription filter; the forwarder does not subscribe to itself.
+		t.resourceCountIs('AWS::Logs::SubscriptionFilter', 2);
+		// One broad invoke permission for CloudWatch Logs (not one per log group).
+		t.hasResourceProperties(
+			'AWS::Lambda::Permission',
+			Match.objectLike({ Principal: 'logs.amazonaws.com', Action: 'lambda:InvokeFunction' }),
+		);
+	});
+
+	it('injects the default noise/severity rules into the forwarder env', async () => {
+		const { stack } = makeStack();
+		dummyFn(stack, 'AlphaFn');
+		await new LogForwarderConstruct({
+			stackName: 'main',
+			ingestHttpUrl: 'http://ingest.example/',
+		}).construct();
+
+		const env = forwarderEnv(Template.fromStack(stack), 'http://ingest.example/');
+		expect(JSON.parse(env.FORWARDER_NOISE_BENIGN)).toEqual(DEFAULT_LOG_NOISE_RULES.benign);
+		expect(JSON.parse(env.FORWARDER_NOISE_DROP)).toEqual(DEFAULT_LOG_NOISE_RULES.drop);
+		expect(JSON.parse(env.FORWARDER_NOISE_DOWNGRADE)).toEqual(DEFAULT_LOG_NOISE_RULES.downgrade);
+	});
+
+	it('uses ONLY custom rules when useDefaults is false', async () => {
+		const { stack } = makeStack();
+		dummyFn(stack, 'AlphaFn');
+		await new LogForwarderConstruct({
+			stackName: 'main',
+			ingestHttpUrl: 'http://only-custom/',
+			noise: { drop: ['^custom-drop$'], useDefaults: false },
+		}).construct();
+
+		const env = forwarderEnv(Template.fromStack(stack), 'http://only-custom/');
+		expect(JSON.parse(env.FORWARDER_NOISE_DROP)).toEqual(['^custom-drop$']);
+		// No defaults merged in → benign/downgrade env vars are absent.
+		expect(env.FORWARDER_NOISE_BENIGN).toBeUndefined();
+		expect(env.FORWARDER_NOISE_DOWNGRADE).toBeUndefined();
+	});
+
+	it("subscribes Lambdas in nested stacks under the forwarder's stack (scope 'stack')", async () => {
+		const { stack } = makeStack();
+		// Controller-style nested stacks under 'main' (how fw24 lays out controllerParentStackName apps).
+		const nestedA = new NestedStack(stack, 'ControllerNestedA');
+		const nestedB = new NestedStack(stack, 'ControllerNestedB');
+		dummyFn(nestedA, 'ControllerAFn');
+		dummyFn(nestedB, 'ControllerBFn');
+		dummyFn(stack, 'MainFn');
+
+		await new LogForwarderConstruct({ stackName: 'main', ingestHttpUrl: 'http://x/' }).construct();
+
+		// Every Lambda in every nested stack must get a subscription filter — not just the main stack's.
+		Template.fromStack(nestedA).resourceCountIs('AWS::Logs::SubscriptionFilter', 1);
+		Template.fromStack(nestedB).resourceCountIs('AWS::Logs::SubscriptionFilter', 1);
+		Template.fromStack(stack).resourceCountIs('AWS::Logs::SubscriptionFilter', 1); // MainFn only
+	});
+
+	it('merges custom rules on top of defaults by default', async () => {
+		const { stack } = makeStack();
+		dummyFn(stack, 'AlphaFn');
+		await new LogForwarderConstruct({
+			stackName: 'main',
+			ingestHttpUrl: 'http://merged/',
+			noise: { drop: ['^extra-drop$'] },
+		}).construct();
+
+		const env = forwarderEnv(Template.fromStack(stack), 'http://merged/');
+		const drop = JSON.parse(env.FORWARDER_NOISE_DROP);
+		expect(drop).toEqual([ ...DEFAULT_LOG_NOISE_RULES.drop, '^extra-drop$' ]);
+	});
+});

--- a/src/constructs/log-forwarder.ts
+++ b/src/constructs/log-forwarder.ts
@@ -1,0 +1,276 @@
+import * as path from 'node:path';
+import { existsSync } from 'node:fs';
+import { Aspects, Duration, RemovalPolicy, Stack, type IAspect } from 'aws-cdk-lib';
+import { ServicePrincipal } from 'aws-cdk-lib/aws-iam';
+import { Function as LambdaFunction, Runtime } from 'aws-cdk-lib/aws-lambda';
+import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
+import { FilterPattern, type IFilterPattern, LogGroup, RetentionDays, SubscriptionFilter } from 'aws-cdk-lib/aws-logs';
+import { LambdaDestination } from 'aws-cdk-lib/aws-logs-destinations';
+import type { IConstruct } from 'constructs';
+import { Fw24 } from '../core/fw24';
+import { FW24Construct, FW24ConstructOutput } from '../interfaces/construct';
+import { IConstructConfig } from '../interfaces/construct-config';
+import { createLogger } from '../logging';
+
+/**
+ * App-owned noise / severity rules, applied per log line inside the forwarder Lambda (layers 2–4 of the
+ * pipeline; see `LogForwarderConstruct`). Each list is an array of regex source strings, matched
+ * case-insensitively against the normalized message. These are complementary to any global severity/
+ * noise handling a shared Vector ingest may also run — this layer lets each app own its own rules and,
+ * for `drop`, saves ingest bandwidth by removing noise at the source.
+ */
+export interface LogForwarderNoiseRules {
+	/** Error-ish lines matching these are downgraded to `warn` (tagged `reclassified: "benign"`). */
+	benign?: string[];
+	/** Lines matching these are dropped entirely — never shipped. */
+	drop?: string[];
+	/** Lines matching these are downgraded to `debug` (tagged `reclassified: "noise"`). */
+	downgrade?: string[];
+	/**
+	 * When true (default), the built-in {@link DEFAULT_LOG_NOISE_RULES} are merged with the lists above.
+	 * Set false to use ONLY the lists you provide (or none).
+	 */
+	useDefaults?: boolean;
+}
+
+export interface LogForwarderConstructConfig extends IConstructConfig {
+	/** Vector/Logtrail HTTP JSON ingest URL. Defaults to `FORWARDER_INGEST_URL` at deploy time. */
+	ingestHttpUrl?: string;
+	/** Base `service` label for shipped logs (env is folded in). Defaults to `FORWARDER_SERVICE`. */
+	service?: string;
+	/**
+	 * Stage/owner label (e.g. `develop`, `prod`, `sandbox-nitin`) — folded into the `service` label
+	 * (`myservice-develop`) and emitted as `env` so develop/prod/per-developer logs are distinguishable
+	 * in Logtrail. Defaults to `FORWARDER_ENV` at deploy time.
+	 */
+	env?: string;
+	/** Optional `x-api-key` when the ingest front requires it. Defaults to `FORWARDER_INGEST_X_API_KEY`. */
+	xApiKey?: string;
+	/** Batch wire format — must match your Vector http source decoding. Default: `json-array`. */
+	batchFormat?: 'ndjson' | 'json-array';
+	/** Max uncompressed bytes per POST (the forwarder splits larger batches). Default: 1,000,000. */
+	maxBatchBytes?: number;
+	/** CloudWatch subscription-filter pattern — the volume/cost lever (e.g. only WARN/ERROR). Default: all events. */
+	filterPattern?: IFilterPattern;
+	/** Extra function construct-path substrings to skip (never subscribe). */
+	excludeFunctionPathSubstrings?: string[];
+	/** App-owned noise/severity rules applied inside the forwarder (layers 2–4). */
+	noise?: LogForwarderNoiseRules;
+	/**
+	 * Which construct tree to subscribe.
+	 * - `'stack'` (default): the forwarder's stack and any nested stacks under it (covers the common
+	 *   satellite app, including per-controller nested stacks parented to the default stack).
+	 * - `'app'`: the whole CDK app — use when a backend has independent top-level stacks (e.g. a separate
+	 *   `persistent`/data stack). Note this creates cross-stack subscription→forwarder references, so
+	 *   verify synth doesn't introduce a cyclic stack dependency.
+	 */
+	subscribeScope?: 'stack' | 'app';
+	/** Forwarder function memory (MB). Default 256. */
+	memorySize?: number;
+	/** Forwarder function timeout (seconds). Default 30. */
+	timeoutSeconds?: number;
+	/**
+	 * Cap forwarder concurrency to protect the ingest from a log storm. Opt-in: reserving concurrency
+	 * subtracts from the account's shared pool, so a bad value can fail deploys in constrained accounts.
+	 * Recommended in prod (e.g. 10–20).
+	 */
+	reservedConcurrency?: number;
+	/** Forwarder's own log retention. Default: one week. */
+	logRetention?: RetentionDays;
+}
+
+/**
+ * Curated, generally-safe default noise/severity rules — mirrors the Logtrail Vector "A1" list so a
+ * backend gets sensible log hygiene out of the box. Merge-in by default; override via
+ * {@link LogForwarderNoiseRules.useDefaults}. Exported so apps can inspect / extend the lists.
+ */
+export const DEFAULT_LOG_NOISE_RULES: Required<Omit<LogForwarderNoiseRules, 'useDefaults'>> = {
+	// Benign "errors" → warn, so error counts stay meaningful.
+	benign: [
+		'\\bECONNRESET\\b',
+		'\\bEPIPE\\b',
+		'broken pipe',
+		'client (?:closed request|disconnected)',
+		'connection reset by peer',
+		'context canceled',
+		'request aborted',
+	],
+	// Health/probe noise → dropped.
+	drop: [
+		'GET /(?:health|healthz|readyz|livez|ping)\\b',
+		'\\bkube-probe\\b',
+		'ELB-HealthChecker',
+	],
+	// Low-value noise → debug (kept, de-emphasised).
+	downgrade: [
+		'deprecation.?warning',
+		'/favicon\\.ico',
+	],
+};
+
+// CDK-internal / custom-resource lambdas we never subscribe (noise + cross-stack singletons),
+// plus the forwarder itself (belt-and-suspenders; it is also excluded by reference).
+const DEFAULT_SKIP_SUBSTRINGS = [
+	'LogRetention',
+	'Custom::',
+	'framework-onEvent',
+	'AWSCDKCfn',
+	'BucketNotificationsHandler',
+	'Provider',
+	'LogForwarder',
+];
+
+class LogShippingAspect implements IAspect {
+	constructor(
+		private readonly forwarder: LambdaFunction,
+		private readonly filterPattern: IFilterPattern,
+		private readonly skipSubstrings: string[],
+	) {}
+
+	visit(node: IConstruct): void {
+		if (!(node instanceof LambdaFunction)) {
+			return;
+		}
+		if (node === this.forwarder) {
+			return; // never subscribe the forwarder to itself — infinite loop
+		}
+		const nodePath = node.node.path;
+		if (this.skipSubstrings.some((s) => nodePath.includes(s))) {
+			return;
+		}
+		if (node.node.tryFindChild('LogShipSubscription')) {
+			return; // aspects can visit a node more than once; add the filter only once
+		}
+		try {
+			new SubscriptionFilter(node, 'LogShipSubscription', {
+				logGroup: node.logGroup,
+				// addPermissions:false — a single wildcard invoke permission is added on the forwarder in
+				// construct(), so we don't accumulate one CfnPermission per log group.
+				destination: new LambdaDestination(this.forwarder, { addPermissions: false }),
+				filterPattern: this.filterPattern,
+			});
+		} catch (err) {
+			// A lambda without an addressable log group (rare CDK internals) must never break synth.
+			// eslint-disable-next-line no-console
+			console.warn(`[LogForwarder] skipped ${nodePath}: ${(err as Error).message}`);
+		}
+	}
+}
+
+/**
+ * Out-of-band log shipping for every Lambda in the app.
+ *
+ * Attaches a CloudWatch Logs subscription filter to each function's log group (via an Aspect), routing
+ * batched, gzipped events to a single tiny forwarder Lambda that ships them to a Vector/Logtrail HTTP
+ * ingest. Nothing runs in the app request path (functions only write stdout), so log volume never
+ * degrades request latency and there are no per-log HTTP calls from the handlers.
+ *
+ * Inside the forwarder, each line runs through a 4-step pipeline: NORMALIZE (peel Lambda prefix, lift
+ * fw24 tslog JSON, strip ANSI) → RECLASSIFY benign errors → DROP noise → DOWNGRADE noise. Steps 2–4 are
+ * app-owned rule lists (see {@link LogForwarderNoiseRules} / {@link DEFAULT_LOG_NOISE_RULES}).
+ *
+ * Deploy-time config is read from `FORWARDER_*` env when not passed explicitly. `FORWARDER_*` is used
+ * (never `LOGTRAIL_*`) on purpose: setting `LOGTRAIL_*` in the deploy shell would activate fw24's
+ * in-process log transport and leak local CDK/synth logs to the ingest.
+ */
+export class LogForwarderConstruct implements FW24Construct {
+	readonly fw24: Fw24 = Fw24.getInstance();
+	readonly logger = createLogger(LogForwarderConstruct.name);
+	name = LogForwarderConstruct.name;
+	dependencies: string[] = [];
+	output!: FW24ConstructOutput;
+	mainStack!: Stack;
+
+	constructor(private readonly config: LogForwarderConstructConfig = {}) {}
+
+	private resolveNoiseEnv(): Record<string, string> {
+		const rules = this.config.noise ?? {};
+		const useDefaults = rules.useDefaults !== false;
+		const merge = (list: string[] | undefined, defaults: string[]): string[] => {
+			const base = useDefaults ? defaults : [];
+			// De-dup while preserving order (defaults first, then app additions).
+			return [ ...new Set([ ...base, ...(list ?? []) ]) ];
+		};
+		const benign = merge(rules.benign, DEFAULT_LOG_NOISE_RULES.benign);
+		const drop = merge(rules.drop, DEFAULT_LOG_NOISE_RULES.drop);
+		const downgrade = merge(rules.downgrade, DEFAULT_LOG_NOISE_RULES.downgrade);
+		const env: Record<string, string> = {};
+		if (benign.length) env.FORWARDER_NOISE_BENIGN = JSON.stringify(benign);
+		if (drop.length) env.FORWARDER_NOISE_DROP = JSON.stringify(drop);
+		if (downgrade.length) env.FORWARDER_NOISE_DOWNGRADE = JSON.stringify(downgrade);
+		return env;
+	}
+
+	async construct(): Promise<void> {
+		// Default stack (no hardcoded name) — respects stackName/parentStackName if the app sets them.
+		this.mainStack = this.fw24.getStack(this.config.stackName, this.config.parentStackName);
+		const o = this.config;
+
+		const forwarderLogGroup = new LogGroup(this.mainStack, 'LogForwarderFunctionLogGroup', {
+			retention: o.logRetention ?? RetentionDays.ONE_WEEK,
+			removalPolicy: RemovalPolicy.DESTROY,
+		});
+
+		const ingestHttpUrl = o.ingestHttpUrl ?? process.env.FORWARDER_INGEST_URL?.trim() ?? '';
+		const service = o.service ?? process.env.FORWARDER_SERVICE?.trim() ?? '';
+		const env = o.env ?? process.env.FORWARDER_ENV?.trim() ?? '';
+		const xApiKey = o.xApiKey ?? process.env.FORWARDER_INGEST_X_API_KEY?.trim();
+
+		if (!ingestHttpUrl) {
+			// Non-fatal: the forwarder handler no-ops without an ingest URL, so a backend can adopt the
+			// construct before the ingest is wired. Warn so it isn't a silent no-op.
+			this.logger.warn(
+				'LogForwarderConstruct: no ingest URL (config.ingestHttpUrl / FORWARDER_INGEST_URL). '
+					+ 'Forwarder deploys but ships nothing until one is set.',
+			);
+		}
+
+		// Framework-owned handler shipped compiled in dist (mirrors mailer/dynamo handlers). Resolve the
+		// compiled `.js` when installed (dist), falling back to the `.ts` source when running from fw24's
+		// own src (unit tests / ts-node dev) where the `.js` hasn't been emitted.
+		const handlerBase = path.join(__dirname, '../core/runtime/log-forwarder-handler');
+		const handlerEntry = existsSync(`${handlerBase}.js`) ? `${handlerBase}.js` : `${handlerBase}.ts`;
+
+		const forwarder = new NodejsFunction(this.mainStack, 'LogForwarderFunction', {
+			entry: handlerEntry,
+			handler: 'handler',
+			runtime: Runtime.NODEJS_22_X,
+			memorySize: o.memorySize ?? 256,
+			timeout: Duration.seconds(o.timeoutSeconds ?? 30),
+			...(o.reservedConcurrency != null ? { reservedConcurrentExecutions: o.reservedConcurrency } : {}),
+			logGroup: forwarderLogGroup,
+			bundling: { externalModules: [ '@aws-sdk' ], minify: true },
+			// Forwarder runtime env is fully FORWARDER_*-namespaced — no LOGTRAIL_* keys, so it can never
+			// collide with fw24's in-process transport.
+			environment: {
+				FORWARDER_INGEST_URL: ingestHttpUrl,
+				FORWARDER_SERVICE: service,
+				FORWARDER_ENV: env,
+				...(xApiKey ? { FORWARDER_INGEST_X_API_KEY: xApiKey } : {}),
+				...(o.batchFormat ? { FORWARDER_BATCH_FORMAT: o.batchFormat } : {}),
+				...(o.maxBatchBytes != null ? { FORWARDER_MAX_BATCH_BYTES: String(o.maxBatchBytes) } : {}),
+				...this.resolveNoiseEnv(),
+			},
+		});
+
+		// One broad invoke permission instead of one per log group: keeps the forwarder's resource
+		// policy small (Lambda caps it at ~20KB) as the number of subscribed functions grows.
+		forwarder.addPermission('AllowCloudWatchLogsInvoke', {
+			principal: new ServicePrincipal('logs.amazonaws.com'),
+			action: 'lambda:InvokeFunction',
+			sourceAccount: this.mainStack.account,
+			sourceArn: `arn:aws:logs:${this.mainStack.region}:${this.mainStack.account}:log-group:*`,
+		});
+
+		const skip = [ ...DEFAULT_SKIP_SUBSTRINGS, ...(o.excludeFunctionPathSubstrings ?? []) ];
+		// 'app' → subscribe every Lambda in the whole CDK app (independent top-level stacks too);
+		// 'stack' (default) → this stack + nested stacks under it.
+		const scopeRoot: IConstruct =
+			o.subscribeScope === 'app' ? this.mainStack.node.root : this.mainStack;
+		Aspects.of(scopeRoot).add(
+			new LogShippingAspect(forwarder, o.filterPattern ?? FilterPattern.allEvents(), skip),
+		);
+
+		this.output = {} as FW24ConstructOutput;
+	}
+}

--- a/src/core/runtime/log-forwarder-handler.ts
+++ b/src/core/runtime/log-forwarder-handler.ts
@@ -1,0 +1,406 @@
+/**
+ * CloudWatch Logs -> Vector/Logtrail forwarder (out-of-band log shipping).
+ *
+ * App Lambdas only write to stdout (CloudWatch) — nothing runs in their request path. A CloudWatch
+ * Logs subscription filter streams batched, gzipped events to this function, which reshapes them to
+ * clean Vector JSON records and ships them to the ingest endpoint over a keep-alive connection,
+ * gzip-compressed and split into bounded sub-batches.
+ *
+ * Processing pipeline per event (see `LogForwarderConstruct`):
+ *   1. NORMALIZE  — peel AWS Lambda's text prefix, lift fw24 tslog JSON, strip ANSI, shorten host.
+ *   2. RECLASSIFY — error-ish lines matching a "benign" pattern → `warn` (`reclassified: "benign"`).
+ *   3. DROP       — lines matching a "drop" pattern are removed entirely (saved bandwidth at source).
+ *   4. DOWNGRADE  — lines matching a "downgrade" pattern → `debug` (`reclassified: "noise"`).
+ * Steps 2–4 are app-owned rule lists (env-injected by the construct), complementary to any global
+ * severity/noise handling a shared Vector ingest may also apply.
+ *
+ * ENV NAMESPACE: this function reads ONLY `FORWARDER_*` env vars — deliberately NOT the `LOGTRAIL_*`
+ * keys used by fw24's in-process log transport. That guarantees the forwarder can never collide with,
+ * or accidentally activate, fw24's in-process Logtrail machinery.
+ *
+ * DEPENDENCY-FREE (node built-ins only) so the forwarder bundle stays tiny and cheap.
+ */
+import { gunzipSync, gzipSync } from 'node:zlib';
+import * as http from 'node:http';
+import * as https from 'node:https';
+import { URL } from 'node:url';
+
+const INGEST_URL = process.env.FORWARDER_INGEST_URL?.trim();
+const BASE_SERVICE = process.env.FORWARDER_SERVICE?.trim() || 'unknown';
+// Stage/owner label (e.g. `develop`, `prod`, `sandbox-nitin`) so develop/prod/per-developer logs are
+// distinguishable — there can be several deployments of one service across envs and developers.
+const ENV = process.env.FORWARDER_ENV?.trim() || 'unknown';
+// The `service` label is what's promoted to a Loki label (and shown in Logtrail), so fold the env into
+// it — `plusfan-trials-develop`, `plusfan-trials-sandbox-nitin`, … — guaranteeing each deployment is
+// distinct at a glance. `env` is also emitted as a structured field for querying.
+const SERVICE = ENV && ENV !== 'unknown' ? `${BASE_SERVICE}-${ENV}` : BASE_SERVICE;
+const X_API_KEY = process.env.FORWARDER_INGEST_X_API_KEY?.trim();
+// The fw24 Logtrail/Vector ingest decodes a JSON array into individual events and REJECTS NDJSON (400),
+// so `json-array` is the default. Override to `ndjson` only for an ingest configured with newline framing.
+const BATCH_FORMAT = (process.env.FORWARDER_BATCH_FORMAT?.trim() || 'json-array') as 'ndjson' | 'json-array';
+/** Max uncompressed bytes per POST — bounds request size so a large CloudWatch batch can't 413 the ingest. */
+const MAX_BATCH_BYTES = Number(process.env.FORWARDER_MAX_BATCH_BYTES) || 1_000_000;
+const POST_TIMEOUT_MS = Number(process.env.FORWARDER_POST_TIMEOUT_MS) || 5000;
+const MAX_RETRIES = 1;
+
+// ── App-level noise / severity rules (layers 2–4). Each env var is a JSON array of regex source
+//    strings; compiled case-insensitively once, here, at cold start. Empty/malformed → no rules. ──
+function compileRules(rawJson: string | undefined): RegExp[] {
+	if (!rawJson) return [];
+	let arr: unknown;
+	try {
+		arr = JSON.parse(rawJson);
+	} catch {
+		return [];
+	}
+	if (!Array.isArray(arr)) return [];
+	const out: RegExp[] = [];
+	for (const src of arr) {
+		if (typeof src !== 'string' || src.length === 0) continue;
+		try {
+			out.push(new RegExp(src, 'i'));
+		} catch {
+			// A bad pattern must never break the forwarder — skip it.
+			// eslint-disable-next-line no-console
+			console.warn('[log-forwarder] ignoring invalid noise pattern:', src);
+		}
+	}
+	return out;
+}
+
+const BENIGN_RULES = compileRules(process.env.FORWARDER_NOISE_BENIGN);
+const DROP_RULES = compileRules(process.env.FORWARDER_NOISE_DROP);
+const DOWNGRADE_RULES = compileRules(process.env.FORWARDER_NOISE_DOWNGRADE);
+const HAS_NOISE_RULES = BENIGN_RULES.length > 0 || DROP_RULES.length > 0 || DOWNGRADE_RULES.length > 0;
+
+// Levels that count as "error-ish" for the benign downgrade (mirrors the Vector A1 list).
+const ERRORISH = new Set([ 'error', 'err', 'fatal', 'critical', 'crit', 'emerg', 'alert', 'panic' ]);
+function anyMatch(rules: RegExp[], msg: string): boolean {
+	for (const re of rules) {
+		if (re.test(msg)) return true;
+	}
+	return false;
+}
+
+// Reused across warm invocations so we don't pay TCP/TLS setup per batch.
+const httpAgent = new http.Agent({ keepAlive: true, maxSockets: 16 });
+const httpsAgent = new https.Agent({ keepAlive: true, maxSockets: 16 });
+
+interface CloudWatchLogsEvent {
+	awslogs: { data: string };
+}
+
+interface DecodedPayload {
+	messageType: string;
+	logGroup: string;
+	logStream: string;
+	logEvents: Array<{ id: string; timestamp: number; message: string }>;
+}
+
+// Lambda platform lines that are pure noise. REPORT is kept by default (carries duration/memory);
+// set FORWARDER_DROP_REPORT=true to drop it too.
+const DROP_REPORT = process.env.FORWARDER_DROP_REPORT?.trim() === 'true';
+function isPlatformNoise(raw: string): boolean {
+	if (raw.startsWith('START RequestId') || raw.startsWith('END RequestId') || raw.startsWith('INIT_START')) {
+		return true;
+	}
+	if (DROP_REPORT && raw.startsWith('REPORT RequestId')) {
+		return true;
+	}
+	return false;
+}
+
+// fw24's tslog colorizes output with ANSI SGR codes (e.g. ESC[32m … ESC[39m) which otherwise ship as
+// literal `[32m` noise in Logtrail. Strip all ANSI escape sequences from shipped text.
+// eslint-disable-next-line no-control-regex
+const ANSI_RE = /\x1b\[[0-9;]*[A-Za-z]/g;
+function stripAnsi(s: string): string {
+	return s.includes('\x1b') ? s.replace(ANSI_RE, '') : s;
+}
+
+function fallbackLevel(raw: string): string {
+	if (/\b(?:ERROR|FATAL)\b/.test(raw)) return 'error';
+	if (/\bWARN(?:ING)?\b/.test(raw)) return 'warn';
+	return 'info';
+}
+
+const KNOWN_LEVELS = new Set([ 'trace', 'debug', 'info', 'warn', 'warning', 'error', 'fatal' ]);
+const ISO_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/;
+
+/**
+ * AWS Lambda emits text logs as `‹iso›\t‹requestId›\t‹LEVEL›\t‹message›`. Peel that prefix off so the
+ * message is just the text, and lift requestId/level out as fields (they're already shown as columns).
+ * Returns null if the line isn't in that format.
+ */
+function parseLambdaPrefix(raw: string): { requestId: string; level: string; message: string } | null {
+	const parts = raw.split('\t');
+	if (parts.length < 4) return null;
+	const [ ts, requestId, lvl, ...rest ] = parts;
+	if (!ISO_RE.test(ts) || !KNOWN_LEVELS.has(lvl.trim().toLowerCase())) return null;
+	return { requestId, level: lvl.trim().toLowerCase(), message: rest.join('\t').trim() };
+}
+
+/**
+ * Turn a verbose CloudWatch log-group / log-stream into a short function name for the `host` label,
+ * e.g. `…-plusfantrialsstreamprocessor…LogGroup…` → `plusfantrialsstreamprocessor`. Falls back to the
+ * raw log group. The full log group is still emitted separately as `logGroup`.
+ */
+function shortHost(logGroup: string, logStream: string): string {
+	// Lambda log stream: "YYYY/MM/DD/<functionName>[$LATEST]<id>" — the cleanest source of the fn name.
+	const sm = logStream.match(/^\d{4}\/\d{2}\/\d{2}\/(.+?)\[\$LATEST\]/);
+	if (sm && sm[1]) {
+		return sm[1].replace(/-[A-Za-z0-9]{6,}$/, ''); // drop the CloudFormation random suffix
+	}
+	// Fallback: parse the log group — strip the `…LogGroup<hash>-<suffix>` tail, take the last segment,
+	// and de-duplicate CDK's doubled construct name (`fooBarfooBar` → `fooBar`).
+	let s = logGroup;
+	const lg = s.indexOf('LogGroup');
+	if (lg > 0) s = s.slice(0, lg);
+	const m = s.match(/(?:stack-|NestedStackResource[0-9A-Fa-f]*-)([^-]+)$/);
+	if (m) s = m[1];
+	if (s.length > 0 && s.length % 2 === 0) {
+		const half = s.length / 2;
+		if (s.slice(0, half) === s.slice(half)) s = s.slice(0, half);
+	}
+	return s || logGroup;
+}
+
+/**
+ * Reshape one CloudWatch log event into a clean Vector record, then apply the app-level noise/severity
+ * rules. Returns `null` when the event should be dropped (platform noise or a "drop" rule match).
+ *
+ * fw24 logs are tslog JSON like `{"0":"the message","1":{...arg},"_meta":{"name":"APIConstruct",
+ * "logLevelName":"INFO","date":"..."}}`. We lift the real message out of the positional keys and the
+ * component/level/time out of `_meta`, so Logtrail shows readable lines instead of a raw JSON blob.
+ * Non-JSON lines (Lambda START/END/REPORT, plain text) pass through unchanged.
+ */
+function toVectorRecord(
+	e: { timestamp: number; message: string },
+	logGroup: string,
+	logStream: string,
+): Record<string, unknown> | null {
+	const raw = (e.message ?? '').replace(/\s+$/, '');
+
+	// ── 1) DROP: Lambda platform lines that are pure noise. ──
+	if (isPlatformNoise(raw.trimStart())) {
+		return null;
+	}
+
+	let message = raw;
+	let level: string | undefined;
+	let logger: string | undefined;
+	let requestId: string | undefined;
+	let tsIso: string | undefined;
+
+	// ── 1) NORMALIZE: peel AWS Lambda's `‹iso›\t‹requestId›\t‹LEVEL›\t‹message›` text prefix, if present.
+	const lambda = parseLambdaPrefix(raw);
+	if (lambda) {
+		requestId = lambda.requestId;
+		level = lambda.level;
+		message = lambda.message;
+	}
+
+	// ── 1) NORMALIZE: if the remaining message is fw24 tslog JSON, lift the real text + component/level/time.
+	const body = message;
+	if (body.charCodeAt(0) === 0x7b /* { */) {
+		try {
+			const o = JSON.parse(body) as Record<string, unknown>;
+			const meta = o._meta as { name?: unknown; logLevelName?: unknown; date?: unknown } | undefined;
+			if (meta && typeof meta === 'object') {
+				if (typeof meta.name === 'string') logger = meta.name;
+				if (typeof meta.logLevelName === 'string') level = meta.logLevelName.toLowerCase();
+				if (typeof meta.date === 'string' && !Number.isNaN(Date.parse(meta.date))) {
+					tsIso = new Date(meta.date).toISOString();
+				}
+			}
+			// Positional args "0".."n" hold the logged message + params.
+			const parts: string[] = [];
+			for (let i = 0; Object.prototype.hasOwnProperty.call(o, String(i)); i++) {
+				const v = o[String(i)];
+				parts.push(typeof v === 'string' ? v : JSON.stringify(v));
+			}
+			if (parts.length > 0) message = parts.join(' ');
+		} catch {
+			// not JSON after all — keep the (prefix-stripped) message
+		}
+	}
+
+	const cleanMessage = stripAnsi(message);
+	let resolvedLevel = level ?? fallbackLevel(raw);
+	let reclassified: string | undefined;
+
+	// ── Layers 2–4: app-level noise / severity rules, applied to the normalized message. ──
+	if (HAS_NOISE_RULES) {
+		// 2) RECLASSIFY: benign "errors" → warn (only downgrade, never upgrade).
+		if (ERRORISH.has(resolvedLevel) && anyMatch(BENIGN_RULES, cleanMessage)) {
+			resolvedLevel = 'warn';
+			reclassified = 'benign';
+		}
+		// 3) DROP: noise removed entirely (never shipped — saves ingest bandwidth at the source).
+		if (anyMatch(DROP_RULES, cleanMessage)) {
+			return null;
+		}
+		// 4) DOWNGRADE: noise kept but de-emphasised to debug.
+		if (anyMatch(DOWNGRADE_RULES, cleanMessage)) {
+			resolvedLevel = 'debug';
+			reclassified = 'noise';
+		}
+	}
+
+	return {
+		service: SERVICE,
+		env: ENV,
+		host: shortHost(logGroup, logStream),
+		...(logger ? { logger } : {}),
+		...(requestId ? { requestId } : {}),
+		level: resolvedLevel,
+		...(reclassified ? { reclassified } : {}),
+		message: cleanMessage,
+		timestamp: tsIso ?? new Date(e.timestamp).toISOString(),
+		logGroup,
+		logStream,
+	};
+}
+
+/** Split pre-serialized lines into sub-batches under MAX_BATCH_BYTES (uncompressed). */
+function chunkLines(lines: string[]): string[][] {
+	const chunks: string[][] = [];
+	let current: string[] = [];
+	let size = 0;
+	for (const line of lines) {
+		const lineBytes = Buffer.byteLength(line) + 1; // +1 for the delimiter
+		if (current.length > 0 && size + lineBytes > MAX_BATCH_BYTES) {
+			chunks.push(current);
+			current = [];
+			size = 0;
+		}
+		current.push(line);
+		size += lineBytes;
+	}
+	if (current.length > 0) {
+		chunks.push(current);
+	}
+	return chunks;
+}
+
+function encodeBody(lines: string[]): string {
+	// lines are already JSON strings
+	return BATCH_FORMAT === 'json-array' ? `[${lines.join(',')}]` : lines.join('\n');
+}
+
+function post(gzipped: Buffer): Promise<void> {
+	return new Promise((resolve, reject) => {
+		const url = new URL(INGEST_URL!);
+		const isHttps = url.protocol === 'https:';
+		const lib = isHttps ? https : http;
+		const req = lib.request(
+			url,
+			{
+				method: 'POST',
+				agent: isHttps ? httpsAgent : httpAgent,
+				headers: {
+					'Content-Type': 'application/json',
+					'Content-Encoding': 'gzip',
+					'Content-Length': gzipped.length,
+					...(X_API_KEY ? { 'x-api-key': X_API_KEY } : {}),
+				},
+			},
+			(res) => {
+				res.resume(); // drain so the socket can be reused
+				const status = res.statusCode ?? 0;
+				if (status >= 200 && status < 300) {
+					resolve();
+				} else {
+					reject(new Error(`ingest responded ${status}`));
+				}
+			},
+		);
+		req.on('error', reject);
+		req.setTimeout(POST_TIMEOUT_MS, () => req.destroy(new Error('ingest timeout')));
+		req.end(gzipped);
+	});
+}
+
+/** POST one chunk with a single retry. Returns false if the chunk was dropped after retries. */
+async function shipWithRetry(gzipped: Buffer): Promise<boolean> {
+	for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+		try {
+			await post(gzipped);
+			return true;
+		} catch (err) {
+			if (attempt === MAX_RETRIES) {
+				// Swallow after retries: a persistent ingest outage must not create a CloudWatch retry storm.
+				// eslint-disable-next-line no-console
+				console.error('[log-forwarder] ship failed, dropping chunk:', (err as Error).message);
+				return false;
+			}
+		}
+	}
+	return false;
+}
+
+/** Emit an alarmable CloudWatch metric (EMF) when records are dropped — no SDK, just structured stdout. */
+function emitDroppedMetric(records: number): void {
+	// eslint-disable-next-line no-console
+	console.log(
+		JSON.stringify({
+			_aws: {
+				Timestamp: Date.now(),
+				CloudWatchMetrics: [
+					{
+						Namespace: 'LogForwarder',
+						Dimensions: [ [ 'service' ] ],
+						Metrics: [ { Name: 'DroppedRecords', Unit: 'Count' } ],
+					},
+				],
+			},
+			service: SERVICE,
+			DroppedRecords: records,
+		}),
+	);
+}
+
+export const handler = async (event: CloudWatchLogsEvent): Promise<void> => {
+	if (!INGEST_URL) {
+		return; // not configured yet — no-op (safe to deploy before wiring the ingest URL)
+	}
+
+	let payload: DecodedPayload;
+	try {
+		payload = JSON.parse(gunzipSync(Buffer.from(event.awslogs.data, 'base64')).toString('utf8')) as DecodedPayload;
+	} catch (err) {
+		// eslint-disable-next-line no-console
+		console.error('[log-forwarder] failed to decode payload:', (err as Error).message);
+		return;
+	}
+
+	if (payload.messageType === 'CONTROL_MESSAGE') {
+		return; // subscription liveness ping
+	}
+	const events = payload.logEvents;
+	if (!Array.isArray(events) || events.length === 0) {
+		return;
+	}
+
+	const lines: string[] = [];
+	for (const e of events) {
+		const record = toVectorRecord(e, payload.logGroup, payload.logStream);
+		if (record !== null) {
+			lines.push(JSON.stringify(record));
+		}
+	}
+	if (lines.length === 0) {
+		return; // whole batch was noise / dropped
+	}
+	let dropped = 0;
+	for (const chunk of chunkLines(lines)) {
+		const gzipped = gzipSync(Buffer.from(encodeBody(chunk)));
+		const ok = await shipWithRetry(gzipped);
+		if (!ok) {
+			dropped += chunk.length;
+		}
+	}
+	if (dropped > 0) {
+		emitDroppedMetric(dropped);
+	}
+};


### PR DESCRIPTION
## What

Adds a first-class **`LogForwarderConstruct`** to fw24 — out-of-band CloudWatch → Vector/Logtrail log shipping for every Lambda in an app, with nothing in the request path. This generalizes the copy that lived in `plusfan-trials-backend` so any fw24 backend can turn it on with one `.use(...)`.

## How it works

A single tiny forwarder Lambda receives every function's logs via a CloudWatch **subscription-filter Aspect** and POSTs them (batched, gzipped, keep-alive) to the ingest. App Lambdas only write stdout — no per-log HTTP calls, no latency impact.

Per line, the forwarder runs a 4-step pipeline:
1. **NORMALIZE** — peel AWS Lambda's `iso\trequestId\tLEVEL\t…` prefix, lift fw24 tslog JSON into a readable message + `logger`/`level`/`timestamp`, strip ANSI, shorten the `host`.
2. **RECLASSIFY** — error-ish lines matching a *benign* pattern → `warn` (`reclassified: "benign"`).
3. **DROP** — lines matching a *drop* pattern are removed at the source (saves ingest bandwidth).
4. **DOWNGRADE** — lines matching a *downgrade* pattern → `debug` (`reclassified: "noise"`).

Layers 2–4 are **app-owned rule lists** (`noise: { benign, drop, downgrade, useDefaults }`, serialized to `FORWARDER_NOISE_*`), with a curated `DEFAULT_LOG_NOISE_RULES` (mirrors the Logtrail Vector "A1" list) on by default.

## Correctness / scale details

- **Nested stacks covered.** The Aspect subscribes every function under the target stack *including nested (controller) stacks* — verified in a unit test and in a real `plusfan-trials-backend` synth (20 subscription filters across the main stack + 13 nested controller stacks).
- **Never subscribes itself** (infinite-loop guard, by reference + skip-list).
- **One broad `logs.amazonaws.com` invoke permission** instead of one CfnPermission per log group — keeps the forwarder's resource policy under Lambda's ~20 KB cap as function count grows.
- **Dependency-free handler** (node builtins only) shipped compiled in `dist` like the mailer/dynamo handlers (`.js` in dist, `.ts` fallback for source/tests).
- CDK-internal / custom-resource lambdas are skipped; a function without an addressable log group can never break synth.

## Config surface (all optional; fall back to `FORWARDER_*` env)

`ingestHttpUrl`, `service`, `env`, `xApiKey`, `batchFormat`, `maxBatchBytes`, `filterPattern`, `excludeFunctionPathSubstrings`, `noise`, `subscribeScope` (`'stack'` default | `'app'`), `memorySize`, `timeoutSeconds`, `reservedConcurrency`, `logRetention`, plus `stackName`/`parentStackName`.

## Tests

`src/constructs/log-forwarder.test.ts` — 5 passing: forwarder creation, subscribes-others-but-not-self, **nested-stack coverage**, and noise-rule env (defaults / custom-only / merge).

## Usage

```ts
import { LogForwarderConstruct } from '@ten24group/fw24';
app.use(new LogForwarderConstruct({ service: 'my-service', env: process.env.APP_ENVIRONMENT }));
// FORWARDER_INGEST_URL=http://logtrail-ingest…:PORT set at deploy
```

_Source-only PR; `dist` is built by the release process. First consumer: `plusfan-trials-backend` (wired + verified against a local build)._
