### PR TITLE
feat(log-forwarder): account/region tagging + infer service/env from fw24 config

### DIFF
--- a/src/constructs/log-forwarder.test.ts
+++ b/src/constructs/log-forwarder.test.ts
@@ -113,6 +113,24 @@ describe('LogForwarderConstruct', () => {
 		Template.fromStack(stack).resourceCountIs('AWS::Logs::SubscriptionFilter', 1); // MainFn only
 	});
 
+	it('infers service + env from fw24 config when not passed', async () => {
+		(Fw24 as any).instance = undefined;
+		const app = new App();
+		const stack = new Stack(app, 'TestStack', { env: { account: '123456789012', region: 'us-east-1' } });
+		const fw24 = Fw24.getInstance();
+		fw24.setApp(app);
+		fw24.setConfig({ name: 'plusfan-trials-backend', region: 'us-east-1', account: '123456789012', environment: 'develop' } as any);
+		fw24.addStack('main', stack);
+		dummyFn(stack, 'AlphaFn');
+
+		// No service/env passed — they should come from fw24's config (APP_NAME / APP_ENVIRONMENT).
+		await new LogForwarderConstruct({ stackName: 'main', ingestHttpUrl: 'http://infer/' }).construct();
+
+		const env = forwarderEnv(Template.fromStack(stack), 'http://infer/');
+		expect(env.FORWARDER_SERVICE).toBe('plusfan-trials-backend');
+		expect(env.FORWARDER_ENV).toBe('develop');
+	});
+
 	it('merges custom rules on top of defaults by default', async () => {
 		const { stack } = makeStack();
 		dummyFn(stack, 'AlphaFn');

--- a/src/constructs/log-forwarder.ts
+++ b/src/constructs/log-forwarder.ts
@@ -36,12 +36,16 @@ export interface LogForwarderNoiseRules {
 export interface LogForwarderConstructConfig extends IConstructConfig {
 	/** Vector/Logtrail HTTP JSON ingest URL. Defaults to `FORWARDER_INGEST_URL` at deploy time. */
 	ingestHttpUrl?: string;
-	/** Base `service` label for shipped logs (env is folded in). Defaults to `FORWARDER_SERVICE`. */
+	/**
+	 * Base `service` label for shipped logs (env is folded in). Usually omit — defaults to the fw24
+	 * app name (`APP_NAME`); override with this option or `FORWARDER_SERVICE`.
+	 */
 	service?: string;
 	/**
 	 * Stage/owner label (e.g. `develop`, `prod`, `sandbox-nitin`) — folded into the `service` label
 	 * (`myservice-develop`) and emitted as `env` so develop/prod/per-developer logs are distinguishable
-	 * in Logtrail. Defaults to `FORWARDER_ENV` at deploy time.
+	 * in Logtrail. Usually omit — defaults to the fw24 environment (`APP_ENVIRONMENT`); override with
+	 * this option or `FORWARDER_ENV`.
 	 */
 	env?: string;
 	/** Optional `x-api-key` when the ingest front requires it. Defaults to `FORWARDER_INGEST_X_API_KEY`. */
@@ -211,9 +215,12 @@ export class LogForwarderConstruct implements FW24Construct {
 			removalPolicy: RemovalPolicy.DESTROY,
 		});
 
+		// service/env default to what fw24 already knows (hydrated from APP_NAME / APP_ENVIRONMENT), so a
+		// backend usually doesn't pass them. Precedence: explicit option > FORWARDER_* env > fw24 config.
+		const cfg = this.fw24.getConfig();
 		const ingestHttpUrl = o.ingestHttpUrl ?? process.env.FORWARDER_INGEST_URL?.trim() ?? '';
-		const service = o.service ?? process.env.FORWARDER_SERVICE?.trim() ?? '';
-		const env = o.env ?? process.env.FORWARDER_ENV?.trim() ?? '';
+		const service = o.service ?? (process.env.FORWARDER_SERVICE?.trim() || this.fw24.appName || '');
+		const env = o.env ?? (process.env.FORWARDER_ENV?.trim() || cfg.environment || '');
 		const xApiKey = o.xApiKey ?? process.env.FORWARDER_INGEST_X_API_KEY?.trim();
 
 		if (!ingestHttpUrl) {

--- a/src/core/runtime/log-forwarder-handler.test.ts
+++ b/src/core/runtime/log-forwarder-handler.test.ts
@@ -95,10 +95,10 @@ describe('log-forwarder handler runtime', () => {
 		);
 		// The drop line is gone → 3 shipped, not 4.
 		expect(recs).toHaveLength(3);
-		const benign = recs.find((r) => r.message.includes('ECONNRESET'));
+		const benign = recs.find((r) => r.message.includes('ECONNRESET'))!;
 		expect(benign.level).toBe('warn');
 		expect(benign.reclassified).toBe('benign');
-		const downgraded = recs.find((r) => r.message.includes('deprecation'));
+		const downgraded = recs.find((r) => r.message.includes('deprecation'))!;
 		expect(downgraded.level).toBe('debug');
 		expect(downgraded.reclassified).toBe('noise');
 		expect(recs.some((r) => r.message.includes('healthz'))).toBe(false);

--- a/src/core/runtime/log-forwarder-handler.test.ts
+++ b/src/core/runtime/log-forwarder-handler.test.ts
@@ -1,0 +1,106 @@
+import { gzipSync, gunzipSync } from 'node:zlib';
+import * as http from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+/**
+ * Runtime tests for the log-forwarder handler: they stand up a local HTTP server as a fake ingest,
+ * invoke the handler with a synthetic CloudWatch Logs event, and assert on the records it ships —
+ * proving the account/region tagging and the noise/severity reduction actually transform lines
+ * (not just that env vars are injected).
+ */
+function makeCwEvent(messages: string[]) {
+	const payload = {
+		messageType: 'DATA_MESSAGE',
+		logGroup: '/aws/lambda/plusfan-trials-foo',
+		logStream: '2024/01/01/[$LATEST]abcdef',
+		logEvents: messages.map((m, i) => ({ id: String(i), timestamp: 1_700_000_000_000, message: m })),
+	};
+	return { awslogs: { data: gzipSync(Buffer.from(JSON.stringify(payload))).toString('base64') } };
+}
+
+async function runHandler(
+	messages: string[],
+	env: Record<string, string>,
+	arn = 'arn:aws:lambda:us-east-1:123456789012:function:fwd',
+): Promise<Array<Record<string, any>>> {
+	const received: Array<Record<string, any>> = [];
+	const server = http.createServer((req, res) => {
+		const chunks: Buffer[] = [];
+		req.on('data', (c) => chunks.push(c as Buffer));
+		req.on('end', () => {
+			try {
+				const json = gunzipSync(Buffer.concat(chunks)).toString('utf8');
+				for (const r of JSON.parse(json)) received.push(r);
+			} catch {
+				/* ignore */
+			}
+			res.writeHead(200);
+			res.end('ok');
+		});
+	});
+	await new Promise<void>((r) => server.listen(0, '127.0.0.1', r));
+	const port = (server.address() as AddressInfo).port;
+
+	jest.resetModules();
+	const prev = { ...process.env };
+	process.env.FORWARDER_INGEST_URL = `http://127.0.0.1:${port}/`;
+	process.env.AWS_REGION = 'us-east-1';
+	Object.assign(process.env, env);
+	try {
+		// Require AFTER env is set (the handler reads env at module load).
+		const { handler } = require('./log-forwarder-handler');
+		await handler(makeCwEvent(messages), { invokedFunctionArn: arn });
+	} finally {
+		process.env = prev;
+		await new Promise<void>((r) => server.close(() => r()));
+	}
+	return received;
+}
+
+describe('log-forwarder handler runtime', () => {
+	it('tags every record with account (from ARN) and region', async () => {
+		const recs = await runHandler(['hello world'], { FORWARDER_SERVICE: 'plusfan-trials', FORWARDER_ENV: 'local' });
+		expect(recs).toHaveLength(1);
+		expect(recs[0].account).toBe('123456789012');
+		expect(recs[0].region).toBe('us-east-1');
+		expect(recs[0].service).toBe('plusfan-trials-local');
+	});
+
+	it('distinguishes same-named deploys in different accounts by account', async () => {
+		const a = await runHandler(['x'], { FORWARDER_SERVICE: 'plusfan-trials', FORWARDER_ENV: 'local' },
+			'arn:aws:lambda:us-east-1:111111111111:function:fwd');
+		const b = await runHandler(['x'], { FORWARDER_SERVICE: 'plusfan-trials', FORWARDER_ENV: 'local' },
+			'arn:aws:lambda:us-east-1:222222222222:function:fwd');
+		// Same service label, but the account field tells them apart.
+		expect(a[0].service).toBe(b[0].service);
+		expect(a[0].account).toBe('111111111111');
+		expect(b[0].account).toBe('222222222222');
+	});
+
+	it('applies noise reduction: benign->warn, drop removed, noise->debug', async () => {
+		const recs = await runHandler(
+			[
+				'2024-01-01T00:00:00.000Z\treqid\tERROR\tECONNRESET while calling upstream', // benign error
+				'GET /healthz probe',      // drop
+				'deprecation warning: old api', // downgrade
+				'a normal info line',      // untouched
+			],
+			{
+				FORWARDER_SERVICE: 'svc',
+				FORWARDER_ENV: 'test',
+				FORWARDER_NOISE_BENIGN: JSON.stringify(['\\bECONNRESET\\b']),
+				FORWARDER_NOISE_DROP: JSON.stringify(['GET /(?:healthz)']),
+				FORWARDER_NOISE_DOWNGRADE: JSON.stringify(['deprecation.?warning']),
+			},
+		);
+		// The drop line is gone → 3 shipped, not 4.
+		expect(recs).toHaveLength(3);
+		const benign = recs.find((r) => r.message.includes('ECONNRESET'));
+		expect(benign.level).toBe('warn');
+		expect(benign.reclassified).toBe('benign');
+		const downgraded = recs.find((r) => r.message.includes('deprecation'));
+		expect(downgraded.level).toBe('debug');
+		expect(downgraded.reclassified).toBe('noise');
+		expect(recs.some((r) => r.message.includes('healthz'))).toBe(false);
+	});
+});

--- a/src/core/runtime/log-forwarder-handler.ts
+++ b/src/core/runtime/log-forwarder-handler.ts
@@ -14,6 +14,10 @@
  * Steps 2–4 are app-owned rule lists (env-injected by the construct), complementary to any global
  * severity/noise handling a shared Vector ingest may also apply.
  *
+ * Every record also carries `account` + `region` (from the forwarder's own ARN) so deployments that
+ * share app + env names — e.g. multiple developers each running `plusfan-trials` (APP_ENVIRONMENT=local)
+ * in their OWN account — stay distinguishable instead of colliding under one `service` label.
+ *
  * ENV NAMESPACE: this function reads ONLY `FORWARDER_*` env vars — deliberately NOT the `LOGTRAIL_*`
  * keys used by fw24's in-process log transport. That guarantees the forwarder can never collide with,
  * or accidentally activate, fw24's in-process Logtrail machinery.
@@ -35,6 +39,18 @@ const ENV = process.env.FORWARDER_ENV?.trim() || 'unknown';
 // distinct at a glance. `env` is also emitted as a structured field for querying.
 const SERVICE = ENV && ENV !== 'unknown' ? `${BASE_SERVICE}-${ENV}` : BASE_SERVICE;
 const X_API_KEY = process.env.FORWARDER_INGEST_X_API_KEY?.trim();
+
+// AWS account + region disambiguate deployments that share app + env names — e.g. several developers
+// each deploying the SAME app (`plusfan-trials`, APP_ENVIRONMENT=local) to their OWN account. Without
+// this, all their logs would collide under one `service` label. Region is set by the Lambda runtime;
+// account is parsed from the invoked function ARN on the first invocation and cached.
+const REGION = process.env.AWS_REGION?.trim() || '';
+let RESOLVED_ACCOUNT = '';
+function accountFromArn(arn: string | undefined): string {
+	// arn:aws:lambda:<region>:<ACCOUNT>:function:<name>
+	const parts = (arn || '').split(':');
+	return parts.length > 4 ? parts[4] : '';
+}
 // The fw24 Logtrail/Vector ingest decodes a JSON array into individual events and REJECTS NDJSON (400),
 // so `json-array` is the default. Override to `ndjson` only for an ingest configured with newline framing.
 const BATCH_FORMAT = (process.env.FORWARDER_BATCH_FORMAT?.trim() || 'json-array') as 'ndjson' | 'json-array';
@@ -250,6 +266,8 @@ function toVectorRecord(
 	return {
 		service: SERVICE,
 		env: ENV,
+		...(RESOLVED_ACCOUNT ? { account: RESOLVED_ACCOUNT } : {}),
+		...(REGION ? { region: REGION } : {}),
 		host: shortHost(logGroup, logStream),
 		...(logger ? { logger } : {}),
 		...(requestId ? { requestId } : {}),
@@ -360,7 +378,15 @@ function emitDroppedMetric(records: number): void {
 	);
 }
 
-export const handler = async (event: CloudWatchLogsEvent): Promise<void> => {
+interface LambdaContextLike {
+	invokedFunctionArn?: string;
+}
+
+export const handler = async (event: CloudWatchLogsEvent, context?: LambdaContextLike): Promise<void> => {
+	// Resolve the account from this forwarder's own ARN once (same for every invocation).
+	if (!RESOLVED_ACCOUNT && context?.invokedFunctionArn) {
+		RESOLVED_ACCOUNT = accountFromArn(context.invokedFunctionArn);
+	}
 	if (!INGEST_URL) {
 		return; // not configured yet — no-op (safe to deploy before wiring the ingest URL)
 	}


### PR DESCRIPTION
## What

Follow-up to #294. Makes forwarded logs **distinguishable across accounts** when the app name and env label are identical.

## Why

Multiple developers deploy the same backend (`plusfan-trials`) with the same `APP_ENVIRONMENT=local` into **their own AWS accounts**. With only `service`/`env` to go on, all their logs collided under a single `plusfan-trials-local` label — you couldn't tell whose deployment a line came from.

## Change

The forwarder now stamps every shipped record with:
- **`account`** — parsed from the forwarder's own `context.invokedFunctionArn` (cached after first invocation; zero config, always correct for the account it runs in).
- **`region`** — from the Lambda runtime's `AWS_REGION`.

So even when `service` collides, `account` (and `region`) tell deployments apart. Shared envs (develop/prod, one account each) are unaffected.

> To make `account` a first-class **facet** in Logtrail (not just a queryable field), promote it to a Loki label in the Vector ingest config — a one-line infra follow-up. As-is it's already filterable via `| json | account="…"`.

## Tests

New handler runtime suite (`log-forwarder-handler.test.ts`) with a fake ingest server:
- tags `account` (from ARN) + `region`;
- **same app+env in two accounts → same `service`, different `account`**;
- noise reduction actually transforms lines: benign→`warn`, drop removed, noise→`debug`.

_Source-only; dist built by release. Verified live: trials deployed to a sandbox, forwarder shipped with 2xx across main + 13 nested controller stacks._

---

## Also: infer `service` + `env` (less boilerplate)

A backend no longer needs to pass `service` or `env` — they default to what fw24 already hydrates from `APP_NAME` / `APP_ENVIRONMENT`. Precedence: explicit option > `FORWARDER_*` env > fw24 config. Combined with the default `'main'` stack, adoption collapses to:

```ts
app.use(new LogForwarderConstruct());   // FORWARDER_INGEST_URL from env; service/env/stack inferred
```

Test added: with no service/env passed, the forwarder env gets `FORWARDER_SERVICE` = app name and `FORWARDER_ENV` = environment.