### PR TITLE
feat(log-forwarder): auto-derive version (GITHUB_SHA / package.json)

### DIFF
--- a/src/constructs/log-forwarder.test.ts
+++ b/src/constructs/log-forwarder.test.ts
@@ -163,8 +163,25 @@ describe('LogForwarderConstruct', () => {
 
 		const env = forwarderEnv(Template.fromStack(stack), 'http://only-fields/');
 		expect(JSON.parse(env.FORWARDER_FIELDS)).toEqual([ 'orderId' ]);
-		// No version passed and none in env → the key is omitted entirely.
-		expect(env.FORWARDER_VERSION).toBeUndefined();
+		// Version is auto-derived (GITHUB_SHA in CI, else the app package.json version), so it's present
+		// even when not passed — the app never has to maintain it.
+		expect(typeof env.FORWARDER_VERSION).toBe('string');
+		expect(env.FORWARDER_VERSION.length).toBeGreaterThan(0);
+	});
+
+	it('auto-derives version from GITHUB_SHA when none is passed (no app/CI wiring)', async () => {
+		const { stack } = makeStack();
+		dummyFn(stack, 'AlphaFn');
+		const prev = process.env.GITHUB_SHA;
+		process.env.GITHUB_SHA = 'abcdef1234567890fedcba';
+		try {
+			await new LogForwarderConstruct({ stackName: 'main', ingestHttpUrl: 'http://autover/' }).construct();
+			const env = forwarderEnv(Template.fromStack(stack), 'http://autover/');
+			expect(env.FORWARDER_VERSION).toBe('abcdef123456'); // first 12 of the commit sha
+		} finally {
+			if (prev === undefined) delete process.env.GITHUB_SHA;
+			else process.env.GITHUB_SHA = prev;
+		}
 	});
 
 	it('merges custom rules on top of defaults by default', async () => {

--- a/src/constructs/log-forwarder.ts
+++ b/src/constructs/log-forwarder.ts
@@ -1,5 +1,5 @@
 import * as path from 'node:path';
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { Aspects, Duration, RemovalPolicy, Stack, type IAspect } from 'aws-cdk-lib';
 import { CfnPermission, Function as LambdaFunction, Runtime } from 'aws-cdk-lib/aws-lambda';
 import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
@@ -71,7 +71,10 @@ export interface LogForwarderConstructConfig extends IConstructConfig {
 	liftFieldDefaults?: boolean;
 	/**
 	 * Release/version stamped on every shipped line (`version` field) so behavior changes can be attributed
-	 * to a deploy. Pass a semver or git sha. Defaults to `FORWARDER_VERSION` at deploy time; omitted if unset.
+	 * to a deploy. Resolved AUTOMATICALLY so neither the app nor CI has to maintain it (see
+	 * {@link LogForwarderConstruct.resolveVersion}): explicit value / `FORWARDER_VERSION` → the CI commit
+	 * (`GITHUB_SHA`, set automatically by GitHub Actions) → the app's `package.json` version → omitted.
+	 * Only set this to force a specific value.
 	 */
 	version?: string;
 	/**
@@ -233,6 +236,28 @@ export class LogForwarderConstruct implements FW24Construct {
 	}
 
 	/** App-declared fields to lift, merged with {@link DEFAULT_LIFT_FIELDS} unless liftFieldDefaults is false. */
+	/**
+	 * Resolve the version stamp automatically — no app code or CI wiring to maintain:
+	 *   explicit config / `FORWARDER_VERSION` → `GITHUB_SHA` (auto in GitHub Actions, first 12) →
+	 *   the app's package.json version (auto-bumped by release CI, read at synth) → '' (omitted).
+	 */
+	private resolveVersion(): string {
+		const explicit = this.config.version?.trim() || process.env.FORWARDER_VERSION?.trim();
+		if (explicit) return explicit;
+		const sha = process.env.GITHUB_SHA?.trim();
+		if (sha) return sha.slice(0, 12);
+		try {
+			const pkgPath = path.join(process.cwd(), 'package.json');
+			if (existsSync(pkgPath)) {
+				const pkg = JSON.parse(readFileSync(pkgPath, 'utf8')) as { version?: unknown };
+				if (typeof pkg.version === 'string' && pkg.version.trim()) return pkg.version.trim();
+			}
+		} catch {
+			/* version is best-effort — never fail synth over it */
+		}
+		return '';
+	}
+
 	private resolveLiftFields(): string[] {
 		const useDefaults = this.config.liftFieldDefaults !== false;
 		const base = useDefaults ? DEFAULT_LIFT_FIELDS : [];
@@ -257,7 +282,7 @@ export class LogForwarderConstruct implements FW24Construct {
 		const env = o.env ?? (process.env.FORWARDER_ENV?.trim() || cfg.environment || '');
 		const xApiKey = o.xApiKey ?? process.env.FORWARDER_INGEST_X_API_KEY?.trim();
 		const liftFields = this.resolveLiftFields();
-		const version = o.version ?? process.env.FORWARDER_VERSION?.trim() ?? '';
+		const version = this.resolveVersion();
 
 		if (!ingestHttpUrl) {
 			// Non-fatal: the forwarder handler no-ops without an ingest URL, so a backend can adopt the


### PR DESCRIPTION
Makes the forwarder `version` stamp fully automatic — **no app code and no CI wiring to maintain**.

At synth the construct resolves version in this order:
1. explicit `version` config / `FORWARDER_VERSION` (override, still wins)
2. **`GITHUB_SHA`** — set automatically by GitHub Actions (first 12 chars)
3. the app's **package.json version** — auto-bumped by release CI, read at synth
4. omitted

So apps just use `new LogForwarderConstruct({ liftFields: [...] })` and every shipped line gets a `version` with zero maintenance. Additive; the explicit override is unchanged.

16 forwarder tests pass; tsc clean; dist is CI-generated (not in this PR).