### PR TITLE
perf(logging): quiet fw24 hot-path noise (stream processor + search indexer)

### DIFF
--- a/src/core/runtime/dynamodb-stream-processor.ts
+++ b/src/core/runtime/dynamodb-stream-processor.ts
@@ -110,7 +110,7 @@ export class DynamoDBStreamToSNSProcessor extends BaseSQSEventProcessor<DynamoDB
             await this.publishStandardBatch(recordsToProcess);
         }
 
-        this.logger.info('Successfully published all stream records to SNS');
+        this.logger.debug('Successfully published all stream records to SNS');
     }
 
     /**

--- a/src/search/indexer/base-search-indexer.ts
+++ b/src/search/indexer/base-search-indexer.ts
@@ -106,12 +106,12 @@ export abstract class BaseSearchIndexer<T extends IEventDataExtractor<TEvent, TP
       groups.set(key, arr);
     }
 
-    this.logger.info('Records grouped for batch processing', {
+    // Hot path: only a cheap summary at debug. The old per-group `groupDetails` array was built on
+    // EVERY batch (arguments are evaluated before the log call, so even a suppressed debug paid for it)
+    // and added no value at the volume the stream/indexer runs at.
+    this.logger.debug('Records grouped for batch processing', {
       totalGroups: groups.size,
-      groupDetails: Array.from(groups.entries()).map(([ key, groupRecords ]) => ({
-        group: key,
-        recordCount: groupRecords.length
-      }))
+      totalRecords: records.length,
     });
 
     // Process each group using BatchProgress
@@ -351,13 +351,13 @@ export abstract class BaseSearchIndexer<T extends IEventDataExtractor<TEvent, TP
 
   protected getIndexName(entityName: string): string {
     const tableNameKey = resolveEnvValueFor({ key: SEARCH_INDEXER_ENV_KEYS.TABLE_NAME_ENV_KEY });
-    this.logger.info('tableNameKey', { tableNameKey });
+    this.logger.debug('tableNameKey', { tableNameKey });
     if (!tableNameKey) {
       throw new SearchValidationError(`${SEARCH_INDEXER_ENV_KEYS.TABLE_NAME_ENV_KEY} environment variable is required to calculate the appropriate index-name`);
     }
 
     const tableName = resolveEnvValueFor({ key: tableNameKey, suffix: 'table' });
-    this.logger.info('tableName', { tableName });
+    this.logger.debug('tableName', { tableName });
 
     if (!tableName) {
       throw new SearchValidationError(`${tableName} environment variable is required to calculate the appropriate index-name`);


### PR DESCRIPTION
Reduces high-volume, low-value logging on the two hot paths that process every record.

**dynamodb-stream-processor**
- per-batch `Successfully published all stream records to SNS`: `info` → `debug`.

**base-search-indexer**
- `Records grouped for batch processing`: dropped the eager `groupDetails` array — it was `Array.from(groups).map(...)` built on **every batch even when debug is suppressed** (args evaluate before the log call). Now a cheap `{ totalGroups, totalRecords }` at `debug`.
- `getIndexName` per-call `tableNameKey` / `tableName`: `info` → `debug`.

No behavior change — pure noise/cost reduction (prod runs at info, so these stop shipping; and the per-batch payload is no longer built). tsc clean.

Left **open for your review** (not merged).