### PR TITLE
feat(logging): source-position pinning (link a log to the exact culprit line)

### DIFF
--- a/src/constructs/__snapshots__/lambda-function.test.ts.snap
+++ b/src/constructs/__snapshots__/lambda-function.test.ts.snap
@@ -21,11 +21,13 @@ exports[`LambdaFunction Construct Snapshot Tests should generate consistent Clou
         ],
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-123456789012-us-east-1",
-          "S3Key": "df550ce743474088f5a6f3fb4299997518c34d8fb95ed4129849c5232e008c79.zip",
+          "S3Key": "47710ad2f787a7f54ea44cfd0a9bf303f1f1121b67f9ae4b88482478be289817.zip",
         },
         "Description": "Test Lambda with full config",
         "Environment": {
           "Variables": {
+            "LOG_SOURCE_POSITION": "warn-error",
+            "NODE_OPTIONS": "--enable-source-maps",
             "VAR1": "value1",
             "VAR2": "value2",
           },
@@ -164,10 +166,13 @@ exports[`LambdaFunction Construct Snapshot Tests should generate consistent Clou
         ],
         "Code": {
           "S3Bucket": "cdk-hnb659fds-assets-123456789012-us-east-1",
-          "S3Key": "10eb9d09fdc04a561df6e9b42d36ddf50934fae3b100a5d56ac2849b22d2706d.zip",
+          "S3Key": "acdd324f9df0c08bcc02b83d8a3ab89345e4244b4ea34365d54d4869b5eeda87.zip",
         },
         "Environment": {
-          "Variables": {},
+          "Variables": {
+            "LOG_SOURCE_POSITION": "warn-error",
+            "NODE_OPTIONS": "--enable-source-maps",
+          },
         },
         "Handler": "index.handler",
         "Layers": [],

--- a/src/constructs/lambda-function.ts
+++ b/src/constructs/lambda-function.ts
@@ -71,6 +71,16 @@ export interface LambdaFunctionProps {
   processorArchitecture?: 'x86_64' | 'arm_64';
 
   /**
+   * Source-position capture for "pin the exact culprit line" code links in Logtrail.
+   *   - `'warn-error'` (default): capture `file:line` for warn/error/fatal only (cheap — hot info/debug
+   *     paths pay nothing). Adds `--enable-source-maps` so positions resolve to real source.
+   *   - `'all'`: capture for every emitted log (adds cost on busy paths).
+   *   - `'off'`: disable entirely.
+   * Only meaningful with sourcemaps on (fw24 default). Set at the app config level to apply to all functions.
+   */
+  logSourcePosition?: 'off' | 'warn-error' | 'all';
+
+  /**
    * Additional properties for the Node.js Lambda function.
    */
   functionProps?: Omit<NodejsFunctionProps, 'layers'> & {
@@ -307,6 +317,21 @@ export class LambdaFunction extends Construct {
     ])!);
 
     props.environmentVariables = props.environmentVariables ?? {};
+
+    // Source-position pinning: capture file:line for the configured levels so Logtrail can link a log to
+    // the exact culprit line. Config-driven (per-construct prop or app config), default 'warn-error'.
+    // When on, add --enable-source-maps (merged) so runtime stacks resolve to source, not the bundle.
+    const positionMode =
+      props.logSourcePosition ?? (fw24.getConfig() as { logSourcePosition?: string }).logSourcePosition ?? 'warn-error';
+    if (positionMode !== 'off') {
+      if (!('LOG_SOURCE_POSITION' in props.environmentVariables)) {
+        props.environmentVariables[ 'LOG_SOURCE_POSITION' ] = positionMode;
+      }
+      const existingNodeOpts = props.environmentVariables[ 'NODE_OPTIONS' ] ?? '';
+      if (!existingNodeOpts.includes('--enable-source-maps')) {
+        props.environmentVariables[ 'NODE_OPTIONS' ] = `${existingNodeOpts} --enable-source-maps`.trim();
+      }
+    }
 
     // * EXPORT the log-level for our logger-instances in the runtime of this lambda
     // See '../logging/index.ts' for more info

--- a/src/core/runtime/log-forwarder-handler.test.ts
+++ b/src/core/runtime/log-forwarder-handler.test.ts
@@ -146,6 +146,30 @@ describe('log-forwarder handler runtime', () => {
 		expect(recs[0].orderId).toBe('5'); // ordinary field still lifted
 	});
 
+	it('lifts source position from _srcloc into codeFile/codeLine and keeps it out of the message', async () => {
+		const line = JSON.stringify({
+			'0': 'charge failed for order',
+			'1': { _srcloc: 'src/services/store-order.service.ts:337' },
+			_meta: { logLevelName: 'ERROR' },
+		});
+		const recs = await runHandler([line], { FORWARDER_SERVICE: 'svc', FORWARDER_ENV: 'test' });
+		expect(recs).toHaveLength(1);
+		expect(recs[0].codeFile).toBe('src/services/store-order.service.ts');
+		expect(recs[0].codeLine).toBe('337');
+		expect(recs[0].message).toBe('charge failed for order'); // _srcloc must NOT be joined into the message
+		expect(recs[0].message).not.toContain('_srcloc');
+	});
+
+	it('lifts source position from tslog native _meta.path (mode all)', async () => {
+		const line = JSON.stringify({
+			'0': 'boom',
+			_meta: { logLevelName: 'ERROR', path: { filePathWithLine: '/var/task/src/lib/pay.ts:12', fileLine: '12' } },
+		});
+		const recs = await runHandler([line], { FORWARDER_SERVICE: 'svc', FORWARDER_ENV: 'test' });
+		expect(recs[0].codeFile).toBe('src/lib/pay.ts');
+		expect(recs[0].codeLine).toBe('12');
+	});
+
 	it('stamps version on every record when FORWARDER_VERSION is set', async () => {
 		const recs = await runHandler(['hello'], {
 			FORWARDER_SERVICE: 'svc',
@@ -153,5 +177,28 @@ describe('log-forwarder handler runtime', () => {
 			FORWARDER_VERSION: '1.2.3-beta.4',
 		});
 		expect(recs[0].version).toBe('1.2.3-beta.4');
+	});
+
+	it('strips tslog\'s "pretty" (non-JSON) date+level prefix so it does not duplicate the TIME/LVL columns', async () => {
+		const line = '2026-07-19 22:27:59.178 INFO AnalyticsMetricsService [getOrdersForPeriod] Found 12 orders for teamId: glob';
+		const recs = await runHandler([line], { FORWARDER_SERVICE: 'plusfan-team-playbook', FORWARDER_ENV: 'backend' });
+		expect(recs).toHaveLength(1);
+		expect(recs[0].level).toBe('info');
+		expect(recs[0].message).toBe('AnalyticsMetricsService [getOrdersForPeriod] Found 12 orders for teamId: glob');
+		expect(recs[0].message).not.toMatch(/^\d{4}-\d{2}-\d{2}/);
+	});
+
+	it('respects an ERROR/WARN level in the pretty tslog prefix', async () => {
+		const recs = await runHandler(
+			['2026-07-19 22:28:04.552 ERROR SportsPersistenceService Persistence batch failed'],
+			{ FORWARDER_SERVICE: 'svc', FORWARDER_ENV: 'test' },
+		);
+		expect(recs[0].level).toBe('error');
+		expect(recs[0].message).toBe('SportsPersistenceService Persistence batch failed');
+	});
+
+	it('leaves an ordinary line that merely starts with digits untouched (no false-positive strip)', async () => {
+		const recs = await runHandler(['404 not found for /widgets/123'], { FORWARDER_SERVICE: 'svc', FORWARDER_ENV: 'test' });
+		expect(recs[0].message).toBe('404 not found for /widgets/123');
 	});
 });

--- a/src/core/runtime/log-forwarder-handler.ts
+++ b/src/core/runtime/log-forwarder-handler.ts
@@ -120,6 +120,7 @@ const VERSION = process.env.FORWARDER_VERSION?.trim() || '';
 const RESERVED_FIELD_KEYS = new Set([
 	'service', 'env', 'account', 'region', 'version', 'host', 'logger', 'requestId',
 	'level', 'reclassified', 'message', 'timestamp', 'logGroup', 'logStream',
+	'codeFile', 'codeLine',
 ]);
 
 /**
@@ -202,6 +203,20 @@ function fallbackLevel(raw: string): string {
 const KNOWN_LEVELS = new Set([ 'trace', 'debug', 'info', 'warn', 'warning', 'error', 'fatal' ]);
 const ISO_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/;
 
+// tslog's "pretty" (non-JSON) console format: `YYYY-MM-DD HH:MM:SS.mmm LEVEL rest…`. The date + level
+// it prints duplicate what Logtrail already shows in the dedicated TIME/LVL columns — peel them off
+// the message like the Lambda-prefix / tslog-JSON branches already do for their own shapes.
+const PRETTY_TSLOG_RE = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}\s+(TRACE|DEBUG|INFO|WARN(?:ING)?|ERROR|FATAL)\s+(.*)$/;
+
+/** Peel a tslog "pretty" `‹date› ‹time› LEVEL ‹rest›` prefix, if the line matches. */
+function parsePrettyTslogPrefix(raw: string): { level: string; message: string } | null {
+	const m = raw.match(PRETTY_TSLOG_RE);
+	if (!m) return null;
+	const [ , lvl, rest ] = m;
+	const level = lvl.toLowerCase().startsWith('warn') ? 'warn' : lvl.toLowerCase();
+	return { level, message: rest };
+}
+
 /**
  * AWS Lambda emits text logs as `‹iso›\t‹requestId›\t‹LEVEL›\t‹message›`. Peel that prefix off so the
  * message is just the text, and lift requestId/level out as fields (they're already shown as columns).
@@ -268,6 +283,7 @@ function toVectorRecord(
 	let correlationId: string | undefined;
 	let tsIso: string | undefined;
 	let lifted: Record<string, string> | undefined;
+	let codeLoc: string | undefined;
 
 	// ── 1) NORMALIZE: peel AWS Lambda's `‹iso›\t‹requestId›\t‹LEVEL›\t‹message›` text prefix, if present.
 	const lambda = parseLambdaPrefix(raw);
@@ -282,7 +298,10 @@ function toVectorRecord(
 	if (body.charCodeAt(0) === 0x7b /* { */) {
 		try {
 			const o = JSON.parse(body) as Record<string, unknown>;
-			const meta = o._meta as { name?: unknown; logLevelName?: unknown; date?: unknown; correlationId?: unknown } | undefined;
+			const meta = o._meta as {
+				name?: unknown; logLevelName?: unknown; date?: unknown; correlationId?: unknown;
+				path?: { filePathWithLine?: unknown; fileName?: unknown; fileLine?: unknown };
+			} | undefined;
 			if (meta && typeof meta === 'object') {
 				if (typeof meta.name === 'string') logger = meta.name;
 				if (typeof meta.logLevelName === 'string') level = meta.logLevelName.toLowerCase();
@@ -290,11 +309,22 @@ function toVectorRecord(
 					tsIso = new Date(meta.date).toISOString();
 				}
 				if (typeof meta.correlationId === 'string' && meta.correlationId.trim()) correlationId = meta.correlationId.trim();
+				// tslog native source position (mode 'all'): _meta.path.
+				const p = meta.path;
+				if (p && typeof p === 'object') {
+					if (typeof p.filePathWithLine === 'string') codeLoc = p.filePathWithLine;
+					else if (typeof p.fileName === 'string' && p.fileLine != null) codeLoc = `${p.fileName}:${p.fileLine}`;
+				}
 			}
-			// Positional args "0".."n" hold the logged message + params.
+			// Positional args "0".."n" hold the logged message + params. A `{ _srcloc }` arg (mode
+			// 'warn-error') carries the caller's source position — lift it, keep it out of the message.
 			const parts: string[] = [];
 			for (let i = 0; Object.prototype.hasOwnProperty.call(o, String(i)); i++) {
 				const v = o[String(i)];
+				if (v && typeof v === 'object' && !Array.isArray(v) && typeof (v as { _srcloc?: unknown })._srcloc === 'string') {
+					if (!codeLoc) codeLoc = (v as { _srcloc: string })._srcloc;
+					continue;
+				}
 				parts.push(typeof v === 'string' ? v : JSON.stringify(v));
 			}
 			if (parts.length > 0) message = parts.join(' ');
@@ -307,11 +337,33 @@ function toVectorRecord(
 		} catch {
 			// not JSON after all — keep the (prefix-stripped) message
 		}
+	} else {
+		// ── 1) NORMALIZE: tslog's "pretty" (non-JSON) console format — strip its own duplicate date+level.
+		const pretty = parsePrettyTslogPrefix(body);
+		if (pretty) {
+			if (!level) level = pretty.level;
+			message = pretty.message;
+		}
 	}
 
 	const cleanMessage = stripAnsi(message);
 	let resolvedLevel = level ?? fallbackLevel(raw);
 	let reclassified: string | undefined;
+
+	// Split the captured source position into queryable `codeFile` + `codeLine` (for "open the exact
+	// culprit line" links). Path is made repo-relative (kept from its last `src/` segment).
+	let codeFile: string | undefined;
+	let codeLine: string | undefined;
+	if (codeLoc) {
+		const m = codeLoc.match(/^(.*?):(\d+)(?::\d+)?$/);
+		if (m) {
+			// Absolute path (…/src/…) → make repo-relative from the last `src/`. Already-relative paths
+			// (the logging layer emits `src/…`) are kept as-is.
+			const srcIdx = m[1].lastIndexOf('/src/');
+			codeFile = srcIdx >= 0 ? m[1].slice(srcIdx + 1) : m[1];
+			codeLine = m[2];
+		}
+	}
 
 	// ── Layers 2–4: app-level noise / severity rules, applied to the normalized message. ──
 	if (HAS_NOISE_RULES) {
@@ -342,6 +394,8 @@ function toVectorRecord(
 		...(requestId ? { requestId } : {}),
 		...(lifted ?? {}),
 		...(correlationId ? { correlationId } : {}),
+		...(codeFile ? { codeFile } : {}),
+		...(codeLine ? { codeLine } : {}),
 		level: resolvedLevel,
 		...(reclassified ? { reclassified } : {}),
 		message: cleanMessage,

--- a/src/logging/index.ts
+++ b/src/logging/index.ts
@@ -19,6 +19,44 @@ const logLevels: any = {
 
 const logLevel = logLevels[ (process.env.LOG_LEVEL || 'info').toLowerCase() ];
 
+/**
+ * Source-position capture mode for "pin the exact culprit" code links. Set by the fw24 function
+ * construct from the `logSourcePosition` app config (default `warn-error`, only when sourcemaps are on):
+ *   - `off`        : never capture position (current prod behaviour).
+ *   - `warn-error` : capture `file:line` ONLY for warn/error/fatal — the culprits worth pinning — so
+ *                    hot info/debug paths pay nothing (captured lazily per-call, see the wrapper below).
+ *   - `all`        : tslog captures position for every emitted log (native `_meta.path`).
+ * Positions only resolve to real source when the Lambda runs with `--enable-source-maps` (the construct
+ * adds it whenever this is enabled).
+ */
+const SOURCE_POSITION_MODE = (process.env.LOG_SOURCE_POSITION?.trim().toLowerCase() || 'off') as
+    'off' | 'warn-error' | 'all';
+
+/** Keep a source path from its last `src/` segment so it maps to a GitHub blob path (best-effort). */
+function repoRelativePath(p: string): string {
+    const i = p.lastIndexOf('/src/');
+    if (i >= 0) return p.slice(i + 1);
+    const slash = p.lastIndexOf('/');
+    return slash >= 0 ? p.slice(slash + 1) : p;
+}
+
+/**
+ * Caller location as `src/file.ts:line` from a fresh stack (source-mapped when `--enable-source-maps`
+ * is on). Skips this module + tslog + node_modules frames so it points at the real call site.
+ */
+function captureSrcLoc(): string | undefined {
+    const stack = new Error().stack;
+    if (!stack) return undefined;
+    const lines = stack.split('\n');
+    for (let i = 2; i < lines.length; i++) {
+        const m = lines[ i ].match(/\(?([^\s()]+\.[cm]?[tj]s):(\d+):\d+\)?\s*$/);
+        if (m && !/node_modules|[/\\]logging[/\\]index|tslog/.test(m[ 1 ])) {
+            return `${repoRelativePath(m[ 1 ])}:${m[ 2 ]}`;
+        }
+    }
+    return undefined;
+}
+
 export const createLogger = (_options: string | Function | ISettingsParam<ILogObj>, _logLevel?: 0 | 1 | 2 | 3 | 4 | 5 | 6) => {
 
     _logLevel = _logLevel ?? logLevel;
@@ -31,9 +69,11 @@ export const createLogger = (_options: string | Function | ISettingsParam<ILogOb
         _options = { name: _options, minLevel: logLevel };
     }
 
-    // show line number only for debug and trace
-    if (!_options.hideLogPositionForProduction && logLevel > 2) {
-        _options.hideLogPositionForProduction = true;
+    // In prod (info+) tslog hides position by default. Only let tslog capture it natively for mode
+    // 'all'; 'warn-error' captures lazily per-call below (cheaper), 'off' stays hidden. An explicit
+    // caller-provided value always wins.
+    if (_options.hideLogPositionForProduction === undefined && logLevel > 2) {
+        _options.hideLogPositionForProduction = SOURCE_POSITION_MODE !== 'all';
     }
 
     // set time format
@@ -73,6 +113,19 @@ export const createLogger = (_options: string | Function | ISettingsParam<ILogOb
     logger.attachTransport(logtrailTransport);
 
     attachCorrelationIdToMeta(logger);
+
+    // Mode 'warn-error': capture source position ONLY for warn/error/fatal (the culprits worth pinning),
+    // so info/debug hot paths pay nothing. Injected as a `_srcloc` arg that the forwarder lifts into
+    // codeFile/codeLine (and strips from the shipped message).
+    if (SOURCE_POSITION_MODE === 'warn-error') {
+        for (const lvl of [ 'warn', 'error', 'fatal' ] as const) {
+            const orig = (logger as any)[ lvl ].bind(logger);
+            (logger as any)[ lvl ] = (...args: any[]) => {
+                const loc = captureSrcLoc();
+                return loc ? orig(...args, { _srcloc: loc }) : orig(...args);
+            };
+        }
+    }
 
     return logger;
 }


### PR DESCRIPTION
Sentry-style **exact-line** code pinning for our branch-deploy model.

**Design (opt-in/out via config, sensible default):**
- `logSourcePosition` app/construct config, default **'warn-error'** — capture `file:line` only for warn/error/fatal (the culprits worth pinning) so hot info/debug paths pay nothing. Also `'all'` / `'off'`.
- When on, the function construct adds `NODE_OPTIONS=--enable-source-maps` (merged) so runtime stacks resolve to real `src/…` (sourceMap is already fw24's default), and sets the runtime `LOG_SOURCE_POSITION`.
- Logging layer captures the caller position lazily for warn/error/fatal (mode 'all' uses tslog native `_meta.path`).
- Forwarder lifts it into **`codeFile` / `codeLine`** (repo-relative), kept out of the shipped message.

Enables UI deep-links `blob/<sha>/<codeFile>#L<codeLine>`. Config, not env, is the interface (env is an internal escape hatch). tsc + 83 tests pass (snapshots updated for the new default env).

Ships in the next fw24 release; then backends bump + the UI adds the line link.