### PR TITLE
feat(log-forwarder): drop-fields config (omit low-value fields, cut size)

### DIFF
--- a/src/constructs/log-forwarder.ts
+++ b/src/constructs/log-forwarder.ts
@@ -70,6 +70,14 @@ export interface LogForwarderConstructConfig extends IConstructConfig {
 	/** Merge {@link DEFAULT_LIFT_FIELDS} with {@link liftFields}. Default true. Set false to lift ONLY your list. */
 	liftFieldDefaults?: boolean;
 	/**
+	 * Record keys to DROP before shipping, to cut ingest/storage size on low-value fields. Merged with
+	 * {@link DEFAULT_DROP_FIELDS} (logStream, logGroup, source_type, reason) unless {@link dropFieldDefaults}
+	 * is false. `host` (derived from logGroup/logStream) is always kept, and core keys can never be dropped.
+	 */
+	dropFields?: string[];
+	/** Merge {@link DEFAULT_DROP_FIELDS} with {@link dropFields}. Default true. Set false to drop ONLY your list. */
+	dropFieldDefaults?: boolean;
+	/**
 	 * Release/version stamped on every shipped line (`version` field) so behavior changes can be attributed
 	 * to a deploy. Resolved AUTOMATICALLY so neither the app nor CI has to maintain it (see
 	 * {@link LogForwarderConstruct.resolveVersion}): explicit value / `FORWARDER_VERSION` → the CI commit
@@ -135,6 +143,12 @@ export const DEFAULT_LOG_NOISE_RULES: Required<Omit<LogForwarderNoiseRules, 'use
  * the moment an app logs it. Apps add their own business ids (orderId, userId, …) via `liftFields`.
  */
 export const DEFAULT_LIFT_FIELDS = [ 'correlationId' ];
+
+/**
+ * Low-value record keys dropped by default to cut ingest/storage size. `host` is derived from
+ * logGroup/logStream and kept, so dropping the raw group/stream loses nothing actionable.
+ */
+export const DEFAULT_DROP_FIELDS = [ 'logStream', 'logGroup', 'source_type', 'reason' ];
 
 // CDK-internal / custom-resource lambdas we never subscribe (noise + cross-stack singletons),
 // plus the forwarder itself (belt-and-suspenders; it is also excluded by reference).
@@ -264,6 +278,13 @@ export class LogForwarderConstruct implements FW24Construct {
 		return [ ...new Set([ ...base, ...(this.config.liftFields ?? []) ].map((s) => s.trim()).filter(Boolean)) ];
 	}
 
+	/** Record keys to drop, merged with {@link DEFAULT_DROP_FIELDS} unless dropFieldDefaults is false. */
+	private resolveDropFields(): string[] {
+		const useDefaults = this.config.dropFieldDefaults !== false;
+		const base = useDefaults ? DEFAULT_DROP_FIELDS : [];
+		return [ ...new Set([ ...base, ...(this.config.dropFields ?? []) ].map((s) => s.trim()).filter(Boolean)) ];
+	}
+
 	async construct(): Promise<void> {
 		// Default stack (no hardcoded name) — respects stackName/parentStackName if the app sets them.
 		this.mainStack = this.fw24.getStack(this.config.stackName, this.config.parentStackName);
@@ -282,6 +303,7 @@ export class LogForwarderConstruct implements FW24Construct {
 		const env = o.env ?? (process.env.FORWARDER_ENV?.trim() || cfg.environment || '');
 		const xApiKey = o.xApiKey ?? process.env.FORWARDER_INGEST_X_API_KEY?.trim();
 		const liftFields = this.resolveLiftFields();
+		const dropFields = this.resolveDropFields();
 		const version = this.resolveVersion();
 
 		if (!ingestHttpUrl) {
@@ -318,6 +340,8 @@ export class LogForwarderConstruct implements FW24Construct {
 				...(o.batchFormat ? { FORWARDER_BATCH_FORMAT: o.batchFormat } : {}),
 				...(o.maxBatchBytes != null ? { FORWARDER_MAX_BATCH_BYTES: String(o.maxBatchBytes) } : {}),
 				...(liftFields.length ? { FORWARDER_FIELDS: JSON.stringify(liftFields) } : {}),
+				// Always set (even when empty) so the handler drops exactly what the config says, not its own default.
+				FORWARDER_DROP_FIELDS: JSON.stringify(dropFields),
 				...(version ? { FORWARDER_VERSION: version } : {}),
 				...this.resolveNoiseEnv(),
 			},

--- a/src/core/runtime/log-forwarder-handler.test.ts
+++ b/src/core/runtime/log-forwarder-handler.test.ts
@@ -170,6 +170,28 @@ describe('log-forwarder handler runtime', () => {
 		expect(recs[0].codeLine).toBe('12');
 	});
 
+	it('drops logStream/logGroup by default (keeps host) to cut size', async () => {
+		const recs = await runHandler(['hello'], { FORWARDER_SERVICE: 'svc', FORWARDER_ENV: 'test' });
+		expect(recs[0].logGroup).toBeUndefined();
+		expect(recs[0].logStream).toBeUndefined();
+		expect(recs[0].host).toBeDefined(); // host (derived) is kept
+		expect(recs[0].message).toBe('hello');
+	});
+
+	it('respects FORWARDER_DROP_FIELDS (empty = drop nothing; core keys never dropped)', async () => {
+		const keepAll = await runHandler(['hi'], { FORWARDER_SERVICE: 'svc', FORWARDER_ENV: 'test', FORWARDER_DROP_FIELDS: '[]' });
+		expect(keepAll[0].logGroup).toBeDefined();
+		expect(keepAll[0].logStream).toBeDefined();
+
+		const custom = await runHandler(['hi'], {
+			FORWARDER_SERVICE: 'svc', FORWARDER_ENV: 'test',
+			FORWARDER_DROP_FIELDS: JSON.stringify(['logGroup', 'service', 'message']),
+		});
+		expect(custom[0].logGroup).toBeUndefined(); // dropped
+		expect(custom[0].service).toBe('svc-test'); // core key never dropped
+		expect(custom[0].message).toBe('hi'); // core key never dropped
+	});
+
 	it('stamps version on every record when FORWARDER_VERSION is set', async () => {
 		const recs = await runHandler(['hello'], {
 			FORWARDER_SERVICE: 'svc',

--- a/src/core/runtime/log-forwarder-handler.ts
+++ b/src/core/runtime/log-forwarder-handler.ts
@@ -116,6 +116,19 @@ const HAS_LIFT_FIELDS = LIFT_SET.size > 0;
 // construct at deploy time (semver or git sha); omitted from records when unset.
 const VERSION = process.env.FORWARDER_VERSION?.trim() || '';
 
+// ── Field drop-list (FORWARDER_DROP_FIELDS): record keys to OMIT before shipping, to cut ingest/storage
+//    size on low-value fields. Default drops logStream/logGroup/source_type/reason (host is still kept).
+//    The construct sets this from the `dropFields` config; unset → the defaults below. Core keys can
+//    never be dropped (belt-and-suspenders against misconfig). ──
+const DEFAULT_DROP_FIELDS = [ 'logStream', 'logGroup', 'source_type', 'reason' ];
+const NEVER_DROP = new Set([ 'service', 'level', 'message', 'timestamp' ]);
+const DROP_SET = new Set(
+	(process.env.FORWARDER_DROP_FIELDS !== undefined
+		? parseFieldList(process.env.FORWARDER_DROP_FIELDS)
+		: DEFAULT_DROP_FIELDS
+	).filter((k) => !NEVER_DROP.has(k)),
+);
+
 // Record keys the forwarder owns — a lifted app field must never overwrite one of these.
 const RESERVED_FIELD_KEYS = new Set([
 	'service', 'env', 'account', 'region', 'version', 'host', 'logger', 'requestId',
@@ -383,7 +396,7 @@ function toVectorRecord(
 		}
 	}
 
-	return {
+	const rec: Record<string, unknown> = {
 		service: SERVICE,
 		env: ENV,
 		...(RESOLVED_ACCOUNT ? { account: RESOLVED_ACCOUNT } : {}),
@@ -403,6 +416,10 @@ function toVectorRecord(
 		logGroup,
 		logStream,
 	};
+	// Drop low-value fields (FORWARDER_DROP_FIELDS) to cut ingest/storage size. `host` (derived from
+	// logGroup/logStream) is kept, so dropping the raw group/stream loses nothing actionable.
+	if (DROP_SET.size) for (const k of DROP_SET) delete rec[k];
+	return rec;
 }
 
 /** Split pre-serialized lines into sub-batches under MAX_BATCH_BYTES (uncompressed). */


### PR DESCRIPTION
Config to **ignore/drop record keys** before shipping, to cut ingest/storage size.

- `FORWARDER_DROP_FIELDS` (construct: `dropFields` + `dropFieldDefaults`), merged with **`DEFAULT_DROP_FIELDS` = logStream, logGroup, source_type, reason** — dropped **by default**.
- `host` (derived from logGroup/logStream) is kept, so nothing actionable is lost.
- Core keys (service/level/message/timestamp) can never be dropped (misconfig guard).
- Opt out / customize via config (`dropFieldDefaults: false` to drop only your list).

tsc + 23 forwarder/construct tests pass.