### PR TITLE
fix(logging): emit JSON in Lambda so the forwarder can lift fields

### DIFF
--- a/src/logging/index.ts
+++ b/src/logging/index.ts
@@ -82,6 +82,12 @@ export const createLogger = (_options: string | Function | ISettingsParam<ILogOb
     }
 
     const logger = new Logger({
+        // In Lambda (and when LOG_FORMAT=json) emit structured JSON so the log-forwarder can lift fields
+        // (correlationId, business ids via liftFields, codeFile/codeLine). tslog's default 'pretty' output
+        // bakes args into the message string and CANNOT be lifted. Locally, keep readable pretty output.
+        type: (process.env.AWS_LAMBDA_FUNCTION_NAME || (process.env.LOG_FORMAT || '').toLowerCase() === 'json')
+            ? 'json'
+            : 'pretty',
         stylePrettyLogs: false,
         maskValuesOfKeys: [ 'password', 'confirmPassword', 'secret', 'token', 'apiKey', 'accessToken', 'refreshToken', 'clientSecret', 'clientId', 'clientToken', 'clientCode', 'clientKey' ],
         maskValuesOfKeysCaseInsensitive: true,


### PR DESCRIPTION
**The reason entity-360 / correlationId / code-pin show nothing.** tslog was emitting **pretty** output (fw24 set `stylePrettyLogs:false`, which only disables colours — it does NOT switch to JSON), so structured args were baked into the message string. The log-forwarder only lifts fields from **JSON** tslog, so `correlationId`, `liftFields` business ids, and `codeFile`/`codeLine` were **all inert** — even for correctly-structured logs like `logger.info('...', { orderId })`.

Fix: emit `type:'json'` in Lambda (`AWS_LAMBDA_FUNCTION_NAME`) or when `LOG_FORMAT=json`; keep human-readable pretty locally. Verified: in Lambda mode `createLogger` now emits `{"0":"…","1":{orderId,…},"_meta":{…}}` → forwarder lifts the ids.

This unblocks the entire lift pipeline. tsc + tests pass.