### PR TITLE
fix(search): stop the misleading warn on every routine search-skip

### DIFF
--- a/src/search/indexer/base-search-indexer.ts
+++ b/src/search/indexer/base-search-indexer.ts
@@ -67,12 +67,15 @@ export abstract class BaseSearchIndexer<T extends IEventDataExtractor<TEvent, TP
     }
 
     if (!this.shouldIndexEntity(entityName)) {
+      // Routine/expected for any entity that doesn't opt into search — not warning-worthy, and
+      // subclasses that override shouldIndexEntity() entirely (e.g. a model.search-driven check)
+      // don't populate these two, so only log them when they actually drove the decision.
       const allowedEntityNames = this.getAllowedEntityNames();
       const excludedEntityNames = this.getExcludedEntityNames();
-      this.logger.warn('Skipping search indexing for entity based on filtering rules', {
+      this.logger.debug('Skipping search indexing for entity based on filtering rules', {
         entityName,
-        allowedEntityNames,
-        excludedEntityNames
+        ...(allowedEntityNames !== undefined ? { allowedEntityNames } : {}),
+        ...(excludedEntityNames !== undefined ? { excludedEntityNames } : {}),
       });
       return null;
     }


### PR DESCRIPTION
## Summary
- `BaseSearchIndexer.preprocessRecord` logged `allowedEntityNames`/`excludedEntityNames` unconditionally at `warn` on every entity `shouldIndexEntity()` skips.
- Subclasses that override `shouldIndexEntity()` entirely with their own logic (e.g. plusfan-app-backend's `MeilisearchSync`, which checks each entity's `model.search` flag instead of allow/exclude lists) never populate those two getters — so the log always showed both as `undefined`, misrepresenting the real reason and making it look like a config-loading bug.
- Also: this is now the *routine, expected* case for any entity that doesn't opt into search (e.g. `syncStatus`), not an exceptional one — `warn` was noisy and alert-prone for normal operation.

## Change
- Downgrade the skip log to `debug`.
- Only include `allowedEntityNames`/`excludedEntityNames` in the log payload when they're actually defined.

## Test plan
- [x] `npm run build` passes
- [ ] Once released and bumped downstream, confirm the `MeilisearchSync` skip log for `syncStatus` etc. no longer fires at `warn` and no longer shows `"[undefined]"` fields