### PR TITLE
fix(log-forwarder): classify Lambda crash/timeout/OOM lines as error

### DIFF
--- a/src/core/runtime/log-forwarder-handler.ts
+++ b/src/core/runtime/log-forwarder-handler.ts
@@ -207,8 +207,14 @@ function stripAnsi(s: string): string {
 	return s.includes('\x1b') ? s.replace(ANSI_RE, '') : s;
 }
 
+// Lambda platform/runtime failures that crash or kill the invocation outright — a timeout, an OOM
+// kill, or the runtime exiting early. None of these carry an ERROR/FATAL/WARN token of their own, so
+// without this they'd fall through to the `info` default and be invisible to error-signature scanning.
+const LAMBDA_CRASH_RE = /task timed out after|process exited before completing request|runtime exited with error|runtime\.(?:exiterror|outofmemory)|out of memory|signal:\s*killed/i;
+
 function fallbackLevel(raw: string): string {
 	if (/\b(?:ERROR|FATAL)\b/.test(raw)) return 'error';
+	if (LAMBDA_CRASH_RE.test(raw)) return 'error';
 	if (/\bWARN(?:ING)?\b/.test(raw)) return 'warn';
 	return 'info';
 }
@@ -328,6 +334,10 @@ function toVectorRecord(
 					if (typeof p.filePathWithLine === 'string') codeLoc = p.filePathWithLine;
 					else if (typeof p.fileName === 'string' && p.fileLine != null) codeLoc = `${p.fileName}:${p.fileLine}`;
 				}
+			} else if (typeof o.errorType === 'string' && typeof o.errorMessage === 'string') {
+				// Lambda's own invocation-error envelope (crash/timeout/OOM reported by the platform, not
+				// by app code) — no `_meta`, so it'd otherwise fall through to the `info` default.
+				level = 'error';
 			}
 			// Lift app-declared structured fields (correlationId, orderId, …) FIRST, so those keys can be
 			// kept OUT of the human message below (no duplicating a lifted id in both the field and the text).


### PR DESCRIPTION
## Summary

The log-forwarder's level classifier (`fallbackLevel` in `src/core/runtime/log-forwarder-handler.ts`) only matched literal `ERROR`/`FATAL`/`WARN` tokens via regex. Two real Lambda failure shapes fell through and shipped as `level=info`, making them invisible to error-signature scanning (which filters on `level=error/fatal/critical`):

1. **Lambda timeout lines** — plain text with no level token, e.g. `Task timed out after 30.03 seconds`.
2. **Lambda's platform invocation-error envelope** — JSON shaped like `{"errorType":"Runtime.ExitError","errorMessage":"...","trace":[...]}` (also `Runtime.OutOfMemory`). It carries no `_meta`, so the existing tslog-JSON message-building branch finds no numeric `"0"` key and `level` is never set from that path, falling through to the `info` default.

## Changes

- Added a `LAMBDA_CRASH_RE` fallback pattern covering known platform-failure phrasings (`Task timed out after`, `Process exited before completing request`, `Runtime exited with error`, `Runtime.ExitError`/`Runtime.OutOfMemory`, `out of memory`, `signal: killed`), consulted by `fallbackLevel()`.
- In the tslog-JSON parsing branch, when there's no `_meta` but the parsed object has top-level `errorType` + `errorMessage` strings, explicitly classify as `level='error'` (Lambda's own invocation-error envelope, not app-code JSON).

No other behavior changed; existing tests untouched and pass unmodified.

## Base branch note

This targets `develop`, not `main` — `log-forwarder-handler.ts` doesn't exist on `main` yet (still un-released there), so a PR into `main` isn't meaningful for this fix.

## Verification

Confirmed empirically (not just by inspection) by running the real, compiled handler end-to-end (fake local HTTP ingest + gzipped CloudWatch Logs event) against 5 sample lines:

| Input | level |
|---|---|
| `Task timed out after 30.03 seconds` | `error` ✅ |
| `{"errorType":"Runtime.ExitError","errorMessage":"...signal: killed","trace":[...]}` | `error` ✅ |
| `{"errorType":"Runtime.OutOfMemory","errorMessage":"...signal: killed","trace":[]}` | `error` ✅ |
| `...Process exited before completing request` | `error` ✅ |
| ordinary line (`handled request for order 991`) | `info` ✅ (no over-matching) |

Also ran:
- `npx jest src/core/runtime/log-forwarder-handler.test.ts` — 15/15 pass (no regressions).
- `npm run build` (`tsc`) — passes clean.
- Full `npx jest` suite — 160 pre-existing failures, identical count with and without this change (confirmed via `git stash`), so unrelated to this fix.

## Test plan

- [ ] Human review of the regex coverage / envelope check
- [ ] Consider adding these cases as permanent tests in `log-forwarder-handler.test.ts` (kept out of this PR's diff per the fix's minimal-scope instructions, but the temporary verification test used to prove correctness is reproducible from the PR body above)

**Not merged** — shared package, needs review before any version bump/rollout.