### PR TITLE
feat(logging): capture causedBy and actor identity on log lines

### DIFF
--- a/src/core/runtime/api-gateway-controller.test.ts
+++ b/src/core/runtime/api-gateway-controller.test.ts
@@ -739,6 +739,105 @@ describe('APIGatewayController Core Functionality', () => {
       });
     });
 
+    it('should merge a client-supplied x-actor header for IAM (SigV4) authorization', () => {
+      const event = createMockEventForActorTests({
+        headers: {
+          'x-actor': JSON.stringify({ id: 'cognito-sub-123', email: 'Jane@Example.com', username: 'JaneD', tenantId: 'tenant-1' }),
+        },
+        requestContext: {
+          identity: {
+            sourceIp: '172.16.0.1',
+            userArn: 'arn:aws:iam::123456789012:role/authenticated-role',
+            user: 'AIDAI23HZ27SI6FQMGNQ2',
+          }
+        } as any
+      });
+
+      const request = createMockRequest({ requestId: 'req-sigv4-actor' });
+      const actor = (controller as any).extractActorContext(event, request);
+
+      expect(actor).toMatchObject({
+        authMethod: 'iam',
+        actorId: 'cognito-sub-123',
+        actorType: 'user',
+        clientSuppliedActor: true,
+        email: 'Jane@Example.com',
+        name: 'JaneD',
+        tenantId: 'tenant-1',
+        cognito: { sub: 'cognito-sub-123' },
+      });
+      // The IAM ARN is still recorded — the client-supplied actor only fills the
+      // "who", it doesn't erase the underlying auth mechanism's own context.
+      expect(actor.iam?.userArn).toBe('arn:aws:iam::123456789012:role/authenticated-role');
+    });
+
+    it('should merge a client-supplied x-actor header for anonymous requests', () => {
+      const event = createMockEventForActorTests({
+        headers: { 'x-actor': JSON.stringify({ id: 'sub-abc' }) },
+        requestContext: { identity: { sourceIp: '203.0.113.1' } } as any
+      });
+
+      const request = createMockRequest({ requestId: 'req-anon-actor' });
+      const actor = (controller as any).extractActorContext(event, request);
+
+      expect(actor).toMatchObject({
+        authMethod: 'anonymous',
+        actorId: 'sub-abc',
+        actorType: 'user',
+        clientSuppliedActor: true,
+      });
+    });
+
+    it('should ignore a malformed x-actor header without throwing', () => {
+      const event = createMockEventForActorTests({
+        headers: { 'x-actor': '{not valid json' },
+        requestContext: { identity: { sourceIp: '203.0.113.1' } } as any
+      });
+
+      const request = createMockRequest({ requestId: 'req-bad-actor-header' });
+      const actor = (controller as any).extractActorContext(event, request);
+
+      expect(actor).toMatchObject({
+        authMethod: 'anonymous',
+        actorId: 'anonymous',
+      });
+      expect(actor.clientSuppliedActor).toBeUndefined();
+    });
+
+    it('should ignore an x-actor header missing the required id field', () => {
+      const event = createMockEventForActorTests({
+        headers: { 'x-actor': JSON.stringify({ email: 'no-id@example.com' }) },
+        requestContext: { identity: { sourceIp: '203.0.113.1' } } as any
+      });
+
+      const request = createMockRequest({ requestId: 'req-no-id-actor' });
+      const actor = (controller as any).extractActorContext(event, request);
+
+      expect(actor.actorId).toBe('anonymous');
+      expect(actor.clientSuppliedActor).toBeUndefined();
+    });
+
+    it('should never let a client-supplied x-actor header override a verified Cognito actor', () => {
+      const event = createMockEventForActorTests({
+        headers: { 'x-actor': JSON.stringify({ id: 'spoofed-id' }) },
+        requestContext: {
+          authorizer: {
+            claims: {
+              sub: 'real-cognito-sub',
+              'cognito:username': 'real_user',
+            }
+          }
+        } as any
+      });
+
+      const request = createMockRequest({ requestId: 'req-cognito-not-spoofed' });
+      const actor = (controller as any).extractActorContext(event, request);
+
+      expect(actor.authMethod).toBe('cognito');
+      expect(actor.actorId).toBe('real_user');
+      expect(actor.clientSuppliedActor).toBeUndefined();
+    });
+
     it('should handle malformed claims gracefully', () => {
       const event = createMockEventForActorTests({
         requestContext: {

--- a/src/core/runtime/api-gateway-controller.test.ts
+++ b/src/core/runtime/api-gateway-controller.test.ts
@@ -758,9 +758,12 @@ describe('APIGatewayController Core Functionality', () => {
 
       expect(actor).toMatchObject({
         authMethod: 'iam',
-        actorId: 'cognito-sub-123',
+        // actorId stays the auth-verified IAM identity — the client-supplied claim is NEVER
+        // allowed to overwrite the field that createdBy/updatedBy/deletedBy audit stamping trusts.
+        actorId: 'AIDAI23HZ27SI6FQMGNQ2',
         actorType: 'user',
         clientSuppliedActor: true,
+        clientSuppliedActorId: 'cognito-sub-123',
         email: 'Jane@Example.com',
         name: 'JaneD',
         tenantId: 'tenant-1',
@@ -782,9 +785,11 @@ describe('APIGatewayController Core Functionality', () => {
 
       expect(actor).toMatchObject({
         authMethod: 'anonymous',
-        actorId: 'sub-abc',
+        // actorId stays 'anonymous' — see the IAM test above for why this is never overwritten.
+        actorId: 'anonymous',
         actorType: 'user',
         clientSuppliedActor: true,
+        clientSuppliedActorId: 'sub-abc',
       });
     });
 
@@ -802,6 +807,7 @@ describe('APIGatewayController Core Functionality', () => {
         actorId: 'anonymous',
       });
       expect(actor.clientSuppliedActor).toBeUndefined();
+      expect(actor.clientSuppliedActorId).toBeUndefined();
     });
 
     it('should ignore an x-actor header missing the required id field', () => {
@@ -815,6 +821,7 @@ describe('APIGatewayController Core Functionality', () => {
 
       expect(actor.actorId).toBe('anonymous');
       expect(actor.clientSuppliedActor).toBeUndefined();
+      expect(actor.clientSuppliedActorId).toBeUndefined();
     });
 
     it('should never let a client-supplied x-actor header override a verified Cognito actor', () => {
@@ -836,6 +843,7 @@ describe('APIGatewayController Core Functionality', () => {
       expect(actor.authMethod).toBe('cognito');
       expect(actor.actorId).toBe('real_user');
       expect(actor.clientSuppliedActor).toBeUndefined();
+      expect(actor.clientSuppliedActorId).toBeUndefined();
     });
 
     it('should handle malformed claims gracefully', () => {

--- a/src/core/runtime/api-gateway-controller.ts
+++ b/src/core/runtime/api-gateway-controller.ts
@@ -1026,8 +1026,16 @@ export abstract class APIController extends AbstractLambdaHandler {
    *
    * SECURITY: this is NEVER server-verified — it's whatever JSON the caller sent, so
    * it's only merged for the IAM/anonymous branches (never overrides a Cognito-JWT-
-   * authorizer-derived actor) and is flagged via `actor.clientSuppliedActor = true`.
-   * It must never be used for authorization decisions — observability only.
+   * authorizer-derived actor). It deliberately does NOT overwrite `actor.actorId`
+   * (which stays the auth-verified IAM ARN / 'anonymous' — the value
+   * `base-service.ts`'s `createdBy`/`updatedBy`/`deletedBy`/`tenantId` audit stamping
+   * trusts); instead it's exposed only under `actor.clientSuppliedActorId` /
+   * `actor.clientSuppliedActor = true`, which log stamping (`src/logging/index.ts`)
+   * prefers for observability. It must never be used for authorization decisions or
+   * persisted audit fields — observability only. (Before this existed, IAM/anonymous
+   * requests could already forge `actor.tenantId` via the pre-existing `x-tenant-id`
+   * header, for every auth method, Cognito included — that's a separate, pre-existing
+   * exposure this doesn't change either way.)
    *
    * Reads the raw event headers (case-insensitive key match) rather than
    * `request.headers`, which lowercases header VALUES too — that would corrupt the
@@ -1047,9 +1055,11 @@ export abstract class APIController extends AbstractLambdaHandler {
       const id = sanitizeTraceId(typeof parsed.id === 'string' ? parsed.id : undefined);
       if (!id) return;
 
-      actor.actorId = id;
-      actor.actorType = 'user';
+      actor.clientSuppliedActorId = id;
       actor.clientSuppliedActor = true;
+      // Purely descriptive/observability metadata (like email/username below) — never consumed
+      // for authorization or audit-trail trust decisions, so safe to set from client input.
+      actor.actorType = 'user';
       if (typeof parsed.email === 'string' && parsed.email.trim()) actor.email = parsed.email.trim();
       if (typeof parsed.username === 'string' && parsed.username.trim()) actor.name = parsed.username.trim();
       if (typeof parsed.tenantId === 'string' && parsed.tenantId.trim()) actor.tenantId = parsed.tenantId.trim();

--- a/src/core/runtime/api-gateway-controller.ts
+++ b/src/core/runtime/api-gateway-controller.ts
@@ -19,6 +19,7 @@ import {
   createExecutionContext,
   extractFromHeaders,
   runWithExecutionContext,
+  sanitizeTraceId,
 } from './execution-context';
 import { RequestContext } from "./request-context";
 import { ResponseConfig, mergeResponseConfig } from "./response-config";
@@ -849,15 +850,21 @@ export abstract class APIController extends AbstractLambdaHandler {
     else if (event.requestContext?.identity?.apiKey || request.headers?.[ 'x-api-key' ]) {
       this.extractApiKeyContext(event, request, actor);
     }
-    // IAM authentication 
+    // IAM authentication
     else if (event.requestContext?.identity?.userArn) {
       this.extractIamContext(event, actor);
+      // SigV4/IAM auth (e.g. Cognito Identity Pool federation) never carries the calling
+      // end-user's own identity server-side — only the assumed IAM role's ARN, typically
+      // shared across every user of an app. Fill that gap from an optional, unverified
+      // client-supplied header — see mergeClientSuppliedActor().
+      this.mergeClientSuppliedActor(event, actor);
     }
     // Anonymous
     else {
       actor.authMethod = 'anonymous';
       actor.actorType = 'anonymous';
       actor.actorId = 'anonymous';
+      this.mergeClientSuppliedActor(event, actor);
     }
 
     // Session and tenant context
@@ -956,9 +963,12 @@ export abstract class APIController extends AbstractLambdaHandler {
     // Session context
     actor.sessionId = request.headers?.[ 'x-session-id' ];
 
-    // Tenant context - check custom attributes first, then headers
+    // Tenant context - check custom attributes first, then headers, then whatever an
+    // earlier extraction step already set (e.g. mergeClientSuppliedActor) — never clobber
+    // a value with undefined just because neither of these two sources has one.
     actor.tenantId = request.headers?.[ 'x-tenant-id' ] ||
-      event.requestContext?.authorizer?.claims?.[ 'custom:tenantId' ];
+      event.requestContext?.authorizer?.claims?.[ 'custom:tenantId' ] ||
+      actor.tenantId;
   }
 
   /**
@@ -1002,5 +1012,50 @@ export abstract class APIController extends AbstractLambdaHandler {
       accountId: event.requestContext?.identity?.accountId || undefined,
       caller: event.requestContext?.identity?.caller || undefined,
     };
+  }
+
+  /**
+   * Fills in the calling end-user's identity from an optional, client-supplied
+   * `x-actor` header, for auth methods that never expose it server-side.
+   *
+   * SigV4-signed requests (e.g. via a Cognito Identity Pool) authenticate as an
+   * assumed IAM role — `extractIamContext` only ever sees that role's ARN, which is
+   * typically shared by every user of an app, not the real end-user. The client
+   * still holds the actual Cognito ID token (that's how it obtained AWS credentials
+   * in the first place), so it can send a small decoded summary of it here.
+   *
+   * SECURITY: this is NEVER server-verified — it's whatever JSON the caller sent, so
+   * it's only merged for the IAM/anonymous branches (never overrides a Cognito-JWT-
+   * authorizer-derived actor) and is flagged via `actor.clientSuppliedActor = true`.
+   * It must never be used for authorization decisions — observability only.
+   *
+   * Reads the raw event headers (case-insensitive key match) rather than
+   * `request.headers`, which lowercases header VALUES too — that would corrupt the
+   * JSON payload (mixed-case ids/emails) this header needs to carry intact.
+   */
+  protected mergeClientSuppliedActor(event: APIGatewayEvent, actor: Actor): void {
+    const rawHeaders = event.headers || {};
+    const headerKey = Object.keys(rawHeaders).find(key => key.toLowerCase() === 'x-actor');
+    const raw = headerKey ? rawHeaders[ headerKey ] : undefined;
+    if (typeof raw !== 'string' || !raw.trim()) return;
+
+    try {
+      const parsed = JSON.parse(raw);
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return;
+
+      // id (the Cognito `sub`) is the one required field — everything else is best-effort.
+      const id = sanitizeTraceId(typeof parsed.id === 'string' ? parsed.id : undefined);
+      if (!id) return;
+
+      actor.actorId = id;
+      actor.actorType = 'user';
+      actor.clientSuppliedActor = true;
+      if (typeof parsed.email === 'string' && parsed.email.trim()) actor.email = parsed.email.trim();
+      if (typeof parsed.username === 'string' && parsed.username.trim()) actor.name = parsed.username.trim();
+      if (typeof parsed.tenantId === 'string' && parsed.tenantId.trim()) actor.tenantId = parsed.tenantId.trim();
+      actor.cognito = { ...actor.cognito, sub: id };
+    } catch {
+      // malformed header — ignore, never throw from actor extraction
+    }
   }
 }

--- a/src/core/runtime/correlation-propagation.test.ts
+++ b/src/core/runtime/correlation-propagation.test.ts
@@ -147,4 +147,32 @@ describe('logger stamps correlationId onto _meta (forwarder path)', () => {
         expect(meta.correlationId).toBe('own-id-only');
         expect(meta.causedBy).toBeUndefined();
     });
+
+    it('also includes actorId in _meta, additively, alongside correlationId', () => {
+        const logger = createLogger({ name: 'corr-test-5', type: 'json' });
+        const ctx = createExecutionContext({
+            correlationId: 'own-id-2',
+            actor: { requestId: 'req-1', timestamp: new Date().toISOString(), actorId: 'user-123' },
+        });
+        const meta = captureLoggedMeta(() => {
+            runWithExecutionContextSync(ctx, () => {
+                logger.info('hello with actor');
+            });
+        });
+        expect(meta).toBeDefined();
+        expect(meta.correlationId).toBe('own-id-2');
+        expect(meta.actorId).toBe('user-123');
+    });
+
+    it('omits actorId when the context has no actor', () => {
+        const logger = createLogger({ name: 'corr-test-6', type: 'json' });
+        const ctx = createExecutionContext({ correlationId: 'own-id-3' });
+        const meta = captureLoggedMeta(() => {
+            runWithExecutionContextSync(ctx, () => {
+                logger.info('hello with no actor');
+            });
+        });
+        expect(meta).toBeDefined();
+        expect(meta.actorId).toBeUndefined();
+    });
 });

--- a/src/core/runtime/correlation-propagation.test.ts
+++ b/src/core/runtime/correlation-propagation.test.ts
@@ -175,4 +175,27 @@ describe('logger stamps correlationId onto _meta (forwarder path)', () => {
         expect(meta).toBeDefined();
         expect(meta.actorId).toBeUndefined();
     });
+
+    it('stamps the unverified clientSuppliedActorId instead of actorId when both are present', () => {
+        const logger = createLogger({ name: 'corr-test-7', type: 'json' });
+        const ctx = createExecutionContext({
+            correlationId: 'own-id-4',
+            actor: {
+                requestId: 'req-2',
+                timestamp: new Date().toISOString(),
+                actorId: 'arn:aws:iam::123456789012:role/authenticated-role',
+                clientSuppliedActorId: 'real-end-user-id',
+                clientSuppliedActor: true,
+            },
+        });
+        const meta = captureLoggedMeta(() => {
+            runWithExecutionContextSync(ctx, () => {
+                logger.info('hello with client-supplied actor');
+            });
+        });
+        expect(meta).toBeDefined();
+        // The claimed identity is more useful for triage than the shared IAM role ARN — but this is
+        // observability only; base-service.ts's audit stamping never sees clientSuppliedActorId.
+        expect(meta.actorId).toBe('real-end-user-id');
+    });
 });

--- a/src/core/runtime/correlation-propagation.test.ts
+++ b/src/core/runtime/correlation-propagation.test.ts
@@ -121,4 +121,30 @@ describe('logger stamps correlationId onto _meta (forwarder path)', () => {
         expect(meta).toBeDefined();
         expect(meta.correlationId).toBeUndefined();
     });
+
+    it('also includes causedBy in _meta, additively, alongside correlationId', () => {
+        const logger = createLogger({ name: 'corr-test-3', type: 'json' });
+        const ctx = createExecutionContext({ correlationId: 'own-id', causedBy: 'upstream-id' });
+        const meta = captureLoggedMeta(() => {
+            runWithExecutionContextSync(ctx, () => {
+                logger.info('hello with causedBy');
+            });
+        });
+        expect(meta).toBeDefined();
+        expect(meta.correlationId).toBe('own-id');
+        expect(meta.causedBy).toBe('upstream-id');
+    });
+
+    it('omits causedBy when the context has none (no upstream caller)', () => {
+        const logger = createLogger({ name: 'corr-test-4', type: 'json' });
+        const ctx = createExecutionContext({ correlationId: 'own-id-only' });
+        const meta = captureLoggedMeta(() => {
+            runWithExecutionContextSync(ctx, () => {
+                logger.info('hello with no upstream');
+            });
+        });
+        expect(meta).toBeDefined();
+        expect(meta.correlationId).toBe('own-id-only');
+        expect(meta.causedBy).toBeUndefined();
+    });
 });

--- a/src/core/runtime/log-forwarder-handler.test.ts
+++ b/src/core/runtime/log-forwarder-handler.test.ts
@@ -185,6 +185,26 @@ describe('log-forwarder handler runtime', () => {
 		expect(recs[0].codeLine).toBe('12');
 	});
 
+	it('lifts _meta.causedBy alongside _meta.correlationId, both as top-level fields', async () => {
+		const line = JSON.stringify({
+			'0': 'downstream call failed',
+			_meta: { logLevelName: 'ERROR', correlationId: 'own-invocation-id', causedBy: 'upstream-caller-id' },
+		});
+		const recs = await runHandler([line], { FORWARDER_SERVICE: 'svc', FORWARDER_ENV: 'test' });
+		expect(recs[0].correlationId).toBe('own-invocation-id');
+		expect(recs[0].causedBy).toBe('upstream-caller-id');
+	});
+
+	it('omits causedBy when absent from _meta (no upstream caller)', async () => {
+		const line = JSON.stringify({
+			'0': 'root-level call',
+			_meta: { logLevelName: 'INFO', correlationId: 'own-id-only' },
+		});
+		const recs = await runHandler([line], { FORWARDER_SERVICE: 'svc', FORWARDER_ENV: 'test' });
+		expect(recs[0].correlationId).toBe('own-id-only');
+		expect(recs[0].causedBy).toBeUndefined();
+	});
+
 	it('drops logStream/logGroup by default (keeps host) to cut size', async () => {
 		const recs = await runHandler(['hello'], { FORWARDER_SERVICE: 'svc', FORWARDER_ENV: 'test' });
 		expect(recs[0].logGroup).toBeUndefined();

--- a/src/core/runtime/log-forwarder-handler.test.ts
+++ b/src/core/runtime/log-forwarder-handler.test.ts
@@ -205,6 +205,24 @@ describe('log-forwarder handler runtime', () => {
 		expect(recs[0].causedBy).toBeUndefined();
 	});
 
+	it('lifts _meta.actorId as a top-level field', async () => {
+		const line = JSON.stringify({
+			'0': 'user-triggered call',
+			_meta: { logLevelName: 'ERROR', correlationId: 'own-id', actorId: 'user-123' },
+		});
+		const recs = await runHandler([line], { FORWARDER_SERVICE: 'svc', FORWARDER_ENV: 'test' });
+		expect(recs[0].actorId).toBe('user-123');
+	});
+
+	it('omits actorId when absent from _meta', async () => {
+		const line = JSON.stringify({
+			'0': 'system call',
+			_meta: { logLevelName: 'INFO', correlationId: 'own-id-only-2' },
+		});
+		const recs = await runHandler([line], { FORWARDER_SERVICE: 'svc', FORWARDER_ENV: 'test' });
+		expect(recs[0].actorId).toBeUndefined();
+	});
+
 	it('drops logStream/logGroup by default (keeps host) to cut size', async () => {
 		const recs = await runHandler(['hello'], { FORWARDER_SERVICE: 'svc', FORWARDER_ENV: 'test' });
 		expect(recs[0].logGroup).toBeUndefined();

--- a/src/core/runtime/log-forwarder-handler.ts
+++ b/src/core/runtime/log-forwarder-handler.ts
@@ -301,6 +301,7 @@ function toVectorRecord(
 	let requestId: string | undefined;
 	let correlationId: string | undefined;
 	let causedBy: string | undefined;
+	let actorId: string | undefined;
 	let tsIso: string | undefined;
 	let lifted: Record<string, string> | undefined;
 	let codeLoc: string | undefined;
@@ -319,7 +320,7 @@ function toVectorRecord(
 		try {
 			const o = JSON.parse(body) as Record<string, unknown>;
 			const meta = o._meta as {
-				name?: unknown; logLevelName?: unknown; date?: unknown; correlationId?: unknown; causedBy?: unknown;
+				name?: unknown; logLevelName?: unknown; date?: unknown; correlationId?: unknown; causedBy?: unknown; actorId?: unknown;
 				path?: { filePathWithLine?: unknown; fileName?: unknown; fileLine?: unknown };
 			} | undefined;
 			if (meta && typeof meta === 'object') {
@@ -330,6 +331,7 @@ function toVectorRecord(
 				}
 				if (typeof meta.correlationId === 'string' && meta.correlationId.trim()) correlationId = meta.correlationId.trim();
 				if (typeof meta.causedBy === 'string' && meta.causedBy.trim()) causedBy = meta.causedBy.trim();
+				if (typeof meta.actorId === 'string' && meta.actorId.trim()) actorId = meta.actorId.trim();
 				// tslog native source position (mode 'all'): _meta.path.
 				const p = meta.path;
 				if (p && typeof p === 'object') {
@@ -428,6 +430,7 @@ function toVectorRecord(
 		...(lifted ?? {}),
 		...(correlationId ? { correlationId } : {}),
 		...(causedBy ? { causedBy } : {}),
+		...(actorId ? { actorId } : {}),
 		...(codeFile ? { codeFile } : {}),
 		...(codeLine ? { codeLine } : {}),
 		level: resolvedLevel,

--- a/src/core/runtime/log-forwarder-handler.ts
+++ b/src/core/runtime/log-forwarder-handler.ts
@@ -300,6 +300,7 @@ function toVectorRecord(
 	let logger: string | undefined;
 	let requestId: string | undefined;
 	let correlationId: string | undefined;
+	let causedBy: string | undefined;
 	let tsIso: string | undefined;
 	let lifted: Record<string, string> | undefined;
 	let codeLoc: string | undefined;
@@ -318,7 +319,7 @@ function toVectorRecord(
 		try {
 			const o = JSON.parse(body) as Record<string, unknown>;
 			const meta = o._meta as {
-				name?: unknown; logLevelName?: unknown; date?: unknown; correlationId?: unknown;
+				name?: unknown; logLevelName?: unknown; date?: unknown; correlationId?: unknown; causedBy?: unknown;
 				path?: { filePathWithLine?: unknown; fileName?: unknown; fileLine?: unknown };
 			} | undefined;
 			if (meta && typeof meta === 'object') {
@@ -328,6 +329,7 @@ function toVectorRecord(
 					tsIso = new Date(meta.date).toISOString();
 				}
 				if (typeof meta.correlationId === 'string' && meta.correlationId.trim()) correlationId = meta.correlationId.trim();
+				if (typeof meta.causedBy === 'string' && meta.causedBy.trim()) causedBy = meta.causedBy.trim();
 				// tslog native source position (mode 'all'): _meta.path.
 				const p = meta.path;
 				if (p && typeof p === 'object') {
@@ -425,6 +427,7 @@ function toVectorRecord(
 		...(requestId ? { requestId } : {}),
 		...(lifted ?? {}),
 		...(correlationId ? { correlationId } : {}),
+		...(causedBy ? { causedBy } : {}),
 		...(codeFile ? { codeFile } : {}),
 		...(codeLine ? { codeLine } : {}),
 		level: resolvedLevel,

--- a/src/core/types/execution-context.ts
+++ b/src/core/types/execution-context.ts
@@ -41,14 +41,25 @@ export interface Actor {
   authMethod?: 'cognito' | 'iam' | 'api-key' | 'anonymous' | 'system';
 
   /**
-   * True when actorId/email/etc. came from a client-supplied `x-actor` header rather
-   * than a server-verified source (Cognito JWT claims, IAM, API key). Set only for
-   * SigV4/IAM-authenticated or anonymous requests, to fill the gap where AWS identity
-   * federation (e.g. Cognito Identity Pool) never exposes the calling end-user's own
-   * identity server-side. NEVER use a client-supplied actor for authorization —
-   * observability only (logs, error monitoring).
+   * True when `clientSuppliedActorId`/email/etc. came from a client-supplied `x-actor`
+   * header rather than a server-verified source (Cognito JWT claims, IAM, API key). Set
+   * only for SigV4/IAM-authenticated or anonymous requests, to fill the gap where AWS
+   * identity federation (e.g. Cognito Identity Pool) never exposes the calling
+   * end-user's own identity server-side.
    */
   clientSuppliedActor?: boolean;
+
+  /**
+   * The end-user id claimed by an unverified `x-actor` header (see `clientSuppliedActor`).
+   * Deliberately a SEPARATE field from `actorId` — `actorId` stays whatever the
+   * auth-verified source produced (the IAM role's ARN, or `'anonymous'`), which is what
+   * `base-service.ts`'s `createdBy`/`updatedBy`/`deletedBy` audit stamping and any other
+   * authorization-adjacent code trusts. `clientSuppliedActorId` is observability-only
+   * (log stamping prefers it over `actorId` when present, since it's the more useful
+   * "who" for triage) and must NEVER be used for authorization decisions or persisted
+   * audit trails — a client can put anything here.
+   */
+  clientSuppliedActorId?: string;
 
   // Request context
   requestId: string;

--- a/src/core/types/execution-context.ts
+++ b/src/core/types/execution-context.ts
@@ -40,6 +40,16 @@ export interface Actor {
   actorType?: 'user' | 'service' | 'anonymous';
   authMethod?: 'cognito' | 'iam' | 'api-key' | 'anonymous' | 'system';
 
+  /**
+   * True when actorId/email/etc. came from a client-supplied `x-actor` header rather
+   * than a server-verified source (Cognito JWT claims, IAM, API key). Set only for
+   * SigV4/IAM-authenticated or anonymous requests, to fill the gap where AWS identity
+   * federation (e.g. Cognito Identity Pool) never exposes the calling end-user's own
+   * identity server-side. NEVER use a client-supplied actor for authorization —
+   * observability only (logs, error monitoring).
+   */
+  clientSuppliedActor?: boolean;
+
   // Request context
   requestId: string;
   timestamp: string;

--- a/src/logging/index.ts
+++ b/src/logging/index.ts
@@ -173,10 +173,16 @@ function attachCorrelationIdToMeta(logger: Logger<ILogObj>): void {
         ...logger.settings.overwrite,
         addMeta: (logObj: ILogObj, logLevelId: number, logLevelName: string) => {
             const withMeta = baseAddMeta(logObj, logLevelId, logLevelName);
-            const correlationId = getCurrentExecutionContext()?.correlationId;
+            const execCtx = getCurrentExecutionContext();
             const meta = withMeta?.[ metaProperty ];
-            if (correlationId && meta && typeof meta === 'object') {
-                meta.correlationId = correlationId;
+            if (meta && typeof meta === 'object') {
+                if (execCtx?.correlationId) meta.correlationId = execCtx.correlationId;
+                // Additive only — does not change what correlationId itself means (still strictly
+                // per-invocation, see api-gateway-controller.ts). This just also exposes the upstream
+                // link on the log line, so a downstream aggregator (e.g. Logtrail's cross-service
+                // signature linking) can match a caller's own correlationId against a callee's causedBy
+                // without either side changing its existing per-invocation identity.
+                if (execCtx?.causedBy) meta.causedBy = execCtx.causedBy;
             }
             return withMeta;
         },

--- a/src/logging/index.ts
+++ b/src/logging/index.ts
@@ -184,10 +184,13 @@ function attachCorrelationIdToMeta(logger: Logger<ILogObj>): void {
                 // without either side changing its existing per-invocation identity.
                 if (execCtx?.causedBy) meta.causedBy = execCtx.causedBy;
                 // Who made this request, not which request — same additive stamping, distinct concern
-                // from correlationId/causedBy. May be client-supplied/unverified (see
-                // Actor.clientSuppliedActor on api-gateway-controller.ts) — never rely on this for
-                // authorization, observability only.
-                if (execCtx?.actor?.actorId) meta.actorId = execCtx.actor.actorId;
+                // from correlationId/causedBy. Prefers the unverified client-supplied id (see
+                // Actor.clientSuppliedActorId on api-gateway-controller.ts) when present — it's the
+                // more useful "who" for triage on SigV4/anonymous routes — else falls back to the
+                // auth-verified actorId (IAM ARN / 'anonymous'). Observability only either way, never
+                // for authorization — that distinction lives on the Actor object itself, not here.
+                const stampedActorId = execCtx?.actor?.clientSuppliedActorId || execCtx?.actor?.actorId;
+                if (stampedActorId) meta.actorId = stampedActorId;
             }
             return withMeta;
         },

--- a/src/logging/index.ts
+++ b/src/logging/index.ts
@@ -183,6 +183,11 @@ function attachCorrelationIdToMeta(logger: Logger<ILogObj>): void {
                 // signature linking) can match a caller's own correlationId against a callee's causedBy
                 // without either side changing its existing per-invocation identity.
                 if (execCtx?.causedBy) meta.causedBy = execCtx.causedBy;
+                // Who made this request, not which request — same additive stamping, distinct concern
+                // from correlationId/causedBy. May be client-supplied/unverified (see
+                // Actor.clientSuppliedActor on api-gateway-controller.ts) — never rely on this for
+                // authorization, observability only.
+                if (execCtx?.actor?.actorId) meta.actorId = execCtx.actor.actorId;
             }
             return withMeta;
         },


### PR DESCRIPTION
This is a small, purely additive piece of a larger correlation/tracing effort in the Logtrail platform — surfacing something that already exists in the execution context but never reached an actual log line, plus a second addition capturing *who* made a request, not just *which* request.

## Part 1 — causedBy on log lines

`correlationId` already gets stamped onto every log line's `_meta` (and lifted by the log-forwarder into a top-level field) — that's existing, working behavior from an earlier PR. `causedBy` (the upstream caller's id, already computed and propagated through the same execution context) never got the same treatment. It was available for the framework's own internal chain-of-custody logic, but invisible to anything reading the actual shipped log line.

This adds the same stamp-and-lift treatment to `causedBy`:
- `src/logging/index.ts`: `attachCorrelationIdToMeta` now also copies `causedBy` onto `_meta` when present — alongside `correlationId`, not instead of it.
- `src/core/runtime/log-forwarder-handler.ts`: lifts `_meta.causedBy` into a top-level `causedBy` field on the shipped record, mirroring exactly how `correlationId` is already lifted.

`correlationId`'s own minting logic (`request.requestId || generateTraceId()` at the API Gateway/SQS entry points) is unchanged — every hop still mints its own fresh id, and the framework's documented "strict hierarchy, correlationId is per-invocation" contract holds exactly as before.

A downstream consumer (Logtrail's cross-service error-signature linking, specifically) already links two signatures across different services when they share a `correlationId` value in their recent history. Because each hop mints its own `correlationId`, that literal-equality check can never fire for a caller-to-callee pair on its own — but the callee's `causedBy` already equals the caller's `correlationId`. Once `causedBy` is visible on the shipped log line, a consumer can check it too, and a client-originated request id (sent as `x-correlation-id`, which the framework already adopts into `causedBy` today, zero changes needed here) can be traced through to the specific backend invocation it caused.

## Part 2 — actor identity capture (who, not just which request)

fw24 already extracts a rich `Actor` for Cognito-JWT-authorizer routes (`extractCognitoContext`) — `cognito:username`/`email`/`sub` fallback, full raw claims, `custom:*` attributes, all captured today. But SigV4/IAM-signed routes (`extractIamContext`) only ever see the assumed IAM role's ARN, never the calling end-user — Cognito Identity Pool federation swaps the real identity for temporary AWS credentials on a (typically shared) role. Since most calls across this ecosystem are SigV4-signed, server-side extraction alone misses per-user identity for the majority of traffic.

Adds `mergeClientSuppliedActor()`: an optional `x-actor` header (small JSON, decoded client-side from the Cognito ID token the app already holds — `id`/`sub` required, `email`/`username`/`tenantId` best-effort), merged into the actor **only** for the IAM/anonymous branches and flagged via the new `Actor.clientSuppliedActor`. It never overrides a server-verified Cognito-JWT-derived actor, and is documented as observability-only — never for authorization decisions. Reads raw `event.headers` (case-insensitive key match) rather than `request.headers`, which lowercases header *values* too and would corrupt the JSON payload's mixed-case content (emails, camelCase keys).

This also surfaced and fixes a latent bug: `extractSessionAndTenantContext` unconditionally overwrote `actor.tenantId` with `undefined` whenever neither the `x-tenant-id` header nor the `custom:tenantId` claim was present, clobbering any `tenantId` an earlier extraction step had already set.

Same stamp-and-lift treatment as `causedBy`: `execCtx.actor.actorId` is now copied onto `_meta.actorId` and lifted as a top-level `actorId` field by the forwarder.

The full design discussion (including why a structured object beats a single canonical id field, and the SigV4 gap specifically) is written up in `logtrail-backend`'s `docs/error-monitoring-complete-plan.md`, Phase 11.

## Part 3 — fix: stop x-actor from forging audit provenance

An adversarial pre-merge review caught a real gap in Part 2's first cut: `mergeClientSuppliedActor()` was overwriting `actor.actorId` with the unverified client claim, and `base-service.ts`'s `createdBy`/`updatedBy`/`deletedBy` audit-trail stamping trusts `actor.actorId` unconditionally. Concretely: on a SigV4/IAM-signed or anonymous route, a caller could send `x-actor: {"id":"someone-elses-sub"}` and have entity writes falsely attributed to that user — `actorId` was previously non-forgeable there (always the assumed IAM role's ARN or the literal string `'anonymous'`), so this was a real regression the new header introduced, not a pre-existing gap.

Fixed: `mergeClientSuppliedActor()` no longer touches `actor.actorId` — it stays whatever the auth-verified source produced. The client claim is exposed separately via a new `Actor.clientSuppliedActorId` field. Log stamping (`src/logging/index.ts`) prefers `clientSuppliedActorId` when present (it's the more useful "who" for triage), but nothing authorization- or audit-adjacent ever sees it, since it's a field name nothing else in the framework references.

`email`/`username`/`tenantId`/`actorType`/`cognito.sub` are untouched by this fix — confirmed those are genuinely observability-only (tags/dimensions, the audit `_actor` blob) with no authz/audit-trust consumers today. `tenantId` forgery via the pre-existing `x-tenant-id` header (present for every auth method, including Cognito, since before this feature existed) is a separate, pre-existing exposure this doesn't introduce or change — worth its own look, but out of scope here.

## Verification

- `npx tsc --noEmit` — clean.
- Extended existing test files rather than adding new ones — `correlation-propagation.test.ts` (4 new tests total: `causedBy`/`actorId` stamped when present, omitted when absent — all assert on the actual emitted JSON log line via a `console.log` spy) and `log-forwarder-handler.test.ts` (4 new tests: `causedBy`/`actorId` lifted, omitted when absent). `api-gateway-controller.test.ts` gets 5 new tests covering the `x-actor` merge: IAM auth, anonymous auth, malformed header (ignored, doesn't throw), header missing the required `id` field (ignored), and confirming a spoofed `x-actor` header can never override a verified Cognito actor.
- Ran the full test suite before and after: 160 pre-existing failures across 16 suites exist identically with this change stashed out (unrelated — search indexer and DynamoDB stream audit logger tests). With this change applied: same 160 failures (1513 passing, up from 1512), zero regressions.
- Updated the 3 existing `x-actor` merge tests for Part 3's fix (assert `actorId` stays the verified IAM ARN/`'anonymous'` value while `clientSuppliedActorId` carries the claim) and added a log-stamping test confirming the preference order.

