### PR TITLE
fix(log-forwarder): stop shipping literal "undefined" as requestId/correlationId/causedBy/actorId

### DIFF
--- a/src/core/runtime/correlation-propagation.test.ts
+++ b/src/core/runtime/correlation-propagation.test.ts
@@ -2,6 +2,9 @@ import {
     sanitizeTraceId,
     extractFromHeaders,
     extractFromSqs,
+    extractFromEventBridge,
+    extractFromStepFunctions,
+    extractFromKinesis,
     createHttpHeaders,
     createExecutionContext,
     runWithExecutionContextSync,
@@ -34,6 +37,29 @@ describe('sanitizeTraceId', () => {
         expect(sanitizeTraceId(undefined)).toBeUndefined();
         expect(sanitizeTraceId(null)).toBeUndefined();
     });
+
+    // Regression: a producer somewhere upstream can stringify an unset value via a
+    // template literal (`${x.correlationId}`) or `String(x)`, yielding the literal
+    // text "undefined" (or "null"/"NaN"). That text is alphanumeric, so it passed the
+    // charset regex and propagated as if it were a real id — this is what showed up as
+    // a bogus 9-character "undefined" trace in Logtrail's Recent Traces list. Reject it
+    // as a defense-in-depth backstop, case-insensitively, whatever the real fix at the
+    // producer turns out to be.
+    it('rejects the literal empty-value tokens "undefined"/"null"/"nan" (any case)', () => {
+        expect(sanitizeTraceId('undefined')).toBeUndefined();
+        expect(sanitizeTraceId('Undefined')).toBeUndefined();
+        expect(sanitizeTraceId('UNDEFINED')).toBeUndefined();
+        expect(sanitizeTraceId('null')).toBeUndefined();
+        expect(sanitizeTraceId('NULL')).toBeUndefined();
+        expect(sanitizeTraceId('nan')).toBeUndefined();
+        expect(sanitizeTraceId('NaN')).toBeUndefined();
+        expect(sanitizeTraceId('  undefined  ')).toBeUndefined();
+    });
+
+    it('does not reject ids that merely contain these tokens as a substring', () => {
+        expect(sanitizeTraceId('undefined-1234')).toBe('undefined-1234');
+        expect(sanitizeTraceId('req_null_terminated')).toBe('req_null_terminated');
+    });
 });
 
 describe('extractFromHeaders: inbound sanitization (P0)', () => {
@@ -54,6 +80,10 @@ describe('extractFromHeaders: inbound sanitization (P0)', () => {
             causedBy: undefined,
         });
     });
+
+    it('drops a literal "undefined" x-correlation-id (a stringified unset value upstream)', () => {
+        expect(extractFromHeaders({ 'x-correlation-id': 'undefined' })).toBeUndefined();
+    });
 });
 
 describe('extractFromSqs: inbound sanitization', () => {
@@ -67,6 +97,37 @@ describe('extractFromSqs: inbound sanitization', () => {
         expect(
             extractFromSqs({ correlationId: { stringValue: 'msg-123' } })
         ).toEqual({ correlationId: 'msg-123', causedBy: undefined, sampled: false });
+    });
+
+    it('drops a literal "undefined" correlationId attribute (a stringified unset value upstream)', () => {
+        expect(
+            extractFromSqs({ correlationId: { stringValue: 'undefined' } })
+        ).toBeUndefined();
+    });
+});
+
+describe('extractFromEventBridge / extractFromStepFunctions / extractFromKinesis: literal-token rejection', () => {
+    it('EventBridge: drops a literal "undefined" correlationId in detail', () => {
+        expect(extractFromEventBridge({ detail: { correlationId: 'undefined' } })).toBeUndefined();
+    });
+
+    it('EventBridge: drops a literal "undefined" nested traceContext.correlationId', () => {
+        expect(extractFromEventBridge({ detail: { traceContext: { correlationId: 'undefined' } } })).toBeUndefined();
+    });
+
+    it('StepFunctions: drops a literal "null" correlationId', () => {
+        expect(extractFromStepFunctions({ correlationId: 'null' })).toBeUndefined();
+    });
+
+    it('Kinesis: drops a literal "undefined" correlationId embedded in the record data', () => {
+        const data = { correlationId: 'undefined' };
+        const encoded = Buffer.from(JSON.stringify(data), 'utf-8').toString('base64');
+        expect(extractFromKinesis({ kinesis: { data: encoded, partitionKey: 'undefined' } })).toBeUndefined();
+    });
+
+    it('Kinesis: drops a literal "undefined" partitionKey fallback when there is no JSON data match', () => {
+        const encoded = Buffer.from(JSON.stringify({ unrelated: true }), 'utf-8').toString('base64');
+        expect(extractFromKinesis({ kinesis: { data: encoded, partitionKey: 'undefined' } })).toBeUndefined();
     });
 });
 

--- a/src/core/runtime/execution-context/propagation.ts
+++ b/src/core/runtime/execution-context/propagation.ts
@@ -35,6 +35,30 @@ const W3C_PARENT_ID_LENGTH = 16;
 const SAFE_TRACE_ID_RE = /^[A-Za-z0-9._-]{1,128}$/;
 
 /**
+ * Literal "empty value" tokens that are valid per {@link SAFE_TRACE_ID_RE} (they're
+ * alphanumeric) but are never legitimate ids — they're what you get when an unset
+ * JS value is stringified via a template literal (`` `${x.correlationId}` ``) or
+ * `String(x)` instead of being guarded. Rejected case-insensitively as a
+ * defense-in-depth backstop: the real fix is at the producer that stringified an
+ * absent value in the first place, but this stops the bad token from silently
+ * propagating (and being mistaken for a real trace) if a similar mistake happens
+ * again anywhere upstream.
+ */
+const LITERAL_EMPTY_VALUE_TOKENS = new Set([ 'undefined', 'null', 'nan' ]);
+
+/**
+ * True if `trimmedValue` is one of the literal "empty value" tokens (see
+ * {@link LITERAL_EMPTY_VALUE_TOKENS}). Exported so every extraction boundary —
+ * not just the charset-guarded ones behind {@link sanitizeTraceId} — can reject
+ * these tokens, since a producer stringifying an unset id can hit EventBridge
+ * `detail`, Step Functions input, or Kinesis payloads just as easily as an HTTP
+ * header or SQS/SNS attribute.
+ */
+export function isLiteralEmptyValueToken(trimmedValue: string): boolean {
+  return LITERAL_EMPTY_VALUE_TOKENS.has(trimmedValue.toLowerCase());
+}
+
+/**
  * Return `value` only if it is a safe trace/correlation id (see
  * {@link SAFE_TRACE_ID_RE}); otherwise `undefined`. Trims first; treats blank as
  * absent. Use at every UNTRUSTED extraction boundary so nothing charset-unsafe
@@ -43,7 +67,9 @@ const SAFE_TRACE_ID_RE = /^[A-Za-z0-9._-]{1,128}$/;
 export function sanitizeTraceId(value: string | undefined | null): string | undefined {
   if (typeof value !== 'string') return undefined;
   const trimmed = value.trim();
-  return SAFE_TRACE_ID_RE.test(trimmed) ? trimmed : undefined;
+  if (!SAFE_TRACE_ID_RE.test(trimmed)) return undefined;
+  if (isLiteralEmptyValueToken(trimmed)) return undefined;
+  return trimmed;
 }
 
 // ============================================================================
@@ -228,22 +254,24 @@ export function extractFromEventBridge(
 
   // Direct fields
   const correlationId = detail[ 'correlationId' ] || detail[ 'traceId' ];
-  if (typeof correlationId === 'string' && correlationId.trim()) {
+  if (typeof correlationId === 'string' && correlationId.trim() && !isLiteralEmptyValueToken(correlationId.trim())) {
     const causedBy = detail[ 'causedBy' ];
     const sampled = detail[ 'sampled' ];
+    const trimmedCausedBy = typeof causedBy === 'string' ? causedBy.trim() : undefined;
     return {
       correlationId: correlationId.trim(),
-      causedBy: typeof causedBy === 'string' ? causedBy.trim() : undefined,
+      causedBy: trimmedCausedBy && !isLiteralEmptyValueToken(trimmedCausedBy) ? trimmedCausedBy : undefined,
       sampled: typeof sampled === 'boolean' ? sampled : sampled === 'true',
     };
   }
 
   // Nested traceContext object
   const traceContext = detail[ 'traceContext' ] as Record<string, unknown> | undefined;
-  if (traceContext && typeof traceContext.correlationId === 'string') {
+  if (traceContext && typeof traceContext.correlationId === 'string' && traceContext.correlationId.trim() && !isLiteralEmptyValueToken(traceContext.correlationId.trim())) {
+    const trimmedCausedBy = typeof traceContext.causedBy === 'string' ? (traceContext.causedBy as string).trim() : undefined;
     return {
       correlationId: (traceContext.correlationId as string).trim(),
-      causedBy: typeof traceContext.causedBy === 'string' ? (traceContext.causedBy as string).trim() : undefined,
+      causedBy: trimmedCausedBy && !isLiteralEmptyValueToken(trimmedCausedBy) ? trimmedCausedBy : undefined,
       sampled: typeof traceContext.sampled === 'boolean'
         ? traceContext.sampled
         : traceContext.sampled === 'true',
@@ -263,7 +291,7 @@ export function extractFromStepFunctions(
 
   // Direct fields
   const correlationId = input[ 'correlationId' ] || input[ 'traceId' ];
-  if (typeof correlationId === 'string' && correlationId.trim()) {
+  if (typeof correlationId === 'string' && correlationId.trim() && !isLiteralEmptyValueToken(correlationId.trim())) {
     const sampled = input[ 'sampled' ];
     return {
       correlationId: correlationId.trim(),
@@ -273,7 +301,7 @@ export function extractFromStepFunctions(
 
   // Nested traceContext
   const traceContext = input[ 'traceContext' ] as Record<string, unknown> | undefined;
-  if (traceContext && typeof traceContext.correlationId === 'string') {
+  if (traceContext && typeof traceContext.correlationId === 'string' && traceContext.correlationId.trim() && !isLiteralEmptyValueToken(traceContext.correlationId.trim())) {
     return {
       correlationId: (traceContext.correlationId as string).trim(),
       sampled: typeof traceContext.sampled === 'boolean'
@@ -304,12 +332,13 @@ export function extractFromKinesis(
     const decoded = Buffer.from(record.kinesis.data, 'base64').toString('utf-8');
     const data = JSON.parse(decoded) as Record<string, unknown>;
     const correlationId = data[ 'correlationId' ] || data[ 'traceId' ];
-    if (typeof correlationId === 'string' && correlationId.trim()) {
+    if (typeof correlationId === 'string' && correlationId.trim() && !isLiteralEmptyValueToken(correlationId.trim())) {
       const causedBy = data[ 'causedBy' ];
       const sampled = data[ 'sampled' ];
+      const trimmedCausedBy = typeof causedBy === 'string' ? causedBy.trim() : undefined;
       return {
         correlationId: correlationId.trim(),
-        causedBy: typeof causedBy === 'string' ? causedBy.trim() : undefined,
+        causedBy: trimmedCausedBy && !isLiteralEmptyValueToken(trimmedCausedBy) ? trimmedCausedBy : undefined,
         sampled: typeof sampled === 'boolean' ? sampled : sampled === 'true',
       };
     }
@@ -318,7 +347,7 @@ export function extractFromKinesis(
   }
 
   // Fall back to partition key
-  if (record.kinesis.partitionKey) {
+  if (record.kinesis.partitionKey && !isLiteralEmptyValueToken(record.kinesis.partitionKey.trim())) {
     return { correlationId: record.kinesis.partitionKey };
   }
 

--- a/src/core/runtime/log-forwarder-handler.test.ts
+++ b/src/core/runtime/log-forwarder-handler.test.ts
@@ -276,4 +276,39 @@ describe('log-forwarder handler runtime', () => {
 		const recs = await runHandler(['404 not found for /widgets/123'], { FORWARDER_SERVICE: 'svc', FORWARDER_ENV: 'test' });
 		expect(recs[0].message).toBe('404 not found for /widgets/123');
 	});
+
+	// Root cause (found via live Loki data): AWS Lambda's Node.js runtime has no request id yet
+	// during the INIT phase (module load / DI container construction, before the first invocation),
+	// so a line logged then still gets the usual `‹iso›\t‹requestId›\t‹LEVEL›\t‹message›` shape, but
+	// with the still-unset id stringified to the literal text "undefined" by the runtime itself.
+	// Confirmed in production: multiple Lambdas across a consuming service log at cold start
+	// (before their first real invocation), every one carrying `undefined` as its requestId —
+	// which Logtrail's Recent Traces then grouped into one bogus cross-service "trace" literally
+	// named "undefined".
+	it('treats a Lambda-prefix requestId of literal "undefined" as absent (AWS INIT-phase quirk)', async () => {
+		const line = '2026-07-19T22:28:04.552Z\tundefined\tINFO\tService registry initialized';
+		const recs = await runHandler([line], { FORWARDER_SERVICE: 'svc', FORWARDER_ENV: 'test' });
+		expect(recs[0].requestId).toBeUndefined();
+		expect(recs[0].message).toBe('Service registry initialized');
+	});
+
+	it('still lifts a real Lambda-prefix requestId normally', async () => {
+		const line = '2026-07-19T22:28:04.552Z\treq-abc-123\tINFO\thello';
+		const recs = await runHandler([line], { FORWARDER_SERVICE: 'svc', FORWARDER_ENV: 'test' });
+		expect(recs[0].requestId).toBe('req-abc-123');
+	});
+
+	it.each([ 'undefined', 'Undefined', 'null', 'NaN' ])(
+		'rejects a literal "%s" token from _meta.correlationId/causedBy/actorId the same way',
+		async (token) => {
+			const line = JSON.stringify({
+				'0': 'poisoned meta',
+				_meta: { logLevelName: 'INFO', correlationId: token, causedBy: token, actorId: token },
+			});
+			const recs = await runHandler([line], { FORWARDER_SERVICE: 'svc', FORWARDER_ENV: 'test' });
+			expect(recs[0].correlationId).toBeUndefined();
+			expect(recs[0].causedBy).toBeUndefined();
+			expect(recs[0].actorId).toBeUndefined();
+		},
+	);
 });

--- a/src/core/runtime/log-forwarder-handler.ts
+++ b/src/core/runtime/log-forwarder-handler.ts
@@ -222,6 +222,22 @@ function fallbackLevel(raw: string): string {
 const KNOWN_LEVELS = new Set([ 'trace', 'debug', 'info', 'warn', 'warning', 'error', 'fatal' ]);
 const ISO_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/;
 
+// Literal "empty value" tokens — never a legitimate id, but easy to end up with one anyway. The
+// concrete case this guards: AWS Lambda's Node.js runtime has no request id yet during the INIT
+// phase (module load / DI container construction, before the first invocation), so a line logged
+// then still gets the usual `‹iso›\t‹requestId›\t‹LEVEL›\t‹message›` shape, but with the runtime's
+// own still-unset id stringified to the literal text "undefined" — an AWS platform quirk, not an
+// app bug. Left unguarded, this forwarder would faithfully lift that text as a real `requestId`,
+// and Logtrail's Recent Traces would show a bogus trace with every INIT-phase log line from every
+// Lambda in the app grouped under the fake id "undefined". Same idea as fw24's
+// `sanitizeTraceId`/`isLiteralEmptyValueToken` (execution-context/propagation.ts) — kept as its own
+// tiny local copy here rather than an import, since this forwarder is deliberately
+// dependency-free (see file header) and never pulls in the rest of the execution-context module graph.
+const LITERAL_EMPTY_ID_TOKENS = new Set([ 'undefined', 'null', 'nan' ]);
+function isLiteralEmptyIdToken(v: string): boolean {
+	return LITERAL_EMPTY_ID_TOKENS.has(v.trim().toLowerCase());
+}
+
 // tslog's "pretty" (non-JSON) console format: `YYYY-MM-DD HH:MM:SS.mmm LEVEL rest…`. The date + level
 // it prints duplicate what Logtrail already shows in the dedicated TIME/LVL columns — peel them off
 // the message like the Lambda-prefix / tslog-JSON branches already do for their own shapes.
@@ -246,7 +262,13 @@ function parseLambdaPrefix(raw: string): { requestId: string; level: string; mes
 	if (parts.length < 4) return null;
 	const [ ts, requestId, lvl, ...rest ] = parts;
 	if (!ISO_RE.test(ts) || !KNOWN_LEVELS.has(lvl.trim().toLowerCase())) return null;
-	return { requestId, level: lvl.trim().toLowerCase(), message: rest.join('\t').trim() };
+	// INIT-phase lines carry the literal text "undefined" here (see LITERAL_EMPTY_ID_TOKENS) — treat
+	// that as "no request id" rather than a real one, same as if the prefix had no id at all.
+	return {
+		requestId: isLiteralEmptyIdToken(requestId) ? '' : requestId,
+		level: lvl.trim().toLowerCase(),
+		message: rest.join('\t').trim(),
+	};
 }
 
 /**
@@ -329,9 +351,14 @@ function toVectorRecord(
 				if (typeof meta.date === 'string' && !Number.isNaN(Date.parse(meta.date))) {
 					tsIso = new Date(meta.date).toISOString();
 				}
-				if (typeof meta.correlationId === 'string' && meta.correlationId.trim()) correlationId = meta.correlationId.trim();
-				if (typeof meta.causedBy === 'string' && meta.causedBy.trim()) causedBy = meta.causedBy.trim();
-				if (typeof meta.actorId === 'string' && meta.actorId.trim()) actorId = meta.actorId.trim();
+				// Reject the same literal empty-value tokens as the Lambda-prefix requestId above — a
+				// producer upstream stringifying an unset id (`` `${x.correlationId}` `` / `String(x)`)
+				// is just as capable of poisoning these fw24-emitted `_meta` fields as it is an
+				// AWS-emitted request id, and this forwarder is the single place shipping ALL of them
+				// into Logtrail's queryable fields, so it's the natural backstop.
+				if (typeof meta.correlationId === 'string' && meta.correlationId.trim() && !isLiteralEmptyIdToken(meta.correlationId)) correlationId = meta.correlationId.trim();
+				if (typeof meta.causedBy === 'string' && meta.causedBy.trim() && !isLiteralEmptyIdToken(meta.causedBy)) causedBy = meta.causedBy.trim();
+				if (typeof meta.actorId === 'string' && meta.actorId.trim() && !isLiteralEmptyIdToken(meta.actorId)) actorId = meta.actorId.trim();
 				// tslog native source position (mode 'all'): _meta.path.
 				const p = meta.path;
 				if (p && typeof p === 'object') {


### PR DESCRIPTION
## Summary

Root cause of trace/correlation IDs showing up as the literal string "undefined" in Logtrail's Recent Traces (confirmed against live production log data): AWS Lambda's Node.js runtime has no request id yet during the INIT phase (module load / DI container construction, before the first invocation). A log line emitted then still gets the usual `<iso>\t<requestId>\t<LEVEL>\t<message>` shape, but with the still-unset id stringified to the literal text "undefined" by the runtime itself — an AWS platform quirk, not an application bug.

The log-forwarder faithfully lifted that text as a real `requestId`, so downstream aggregation grouped every affected cold-start log line, from every service that logs during init, into one bogus cross-service "trace" literally named "undefined".

## Fix

- `log-forwarder-handler.ts`: reject literal `"undefined"`/`"null"`/`"nan"` (case-insensitive) as soon as a value is adopted into `requestId`, `correlationId`, `causedBy`, or `actorId`.
- `execution-context/propagation.ts`: same guard already added to `sanitizeTraceId` and every extraction boundary (headers, SQS, SNS, EventBridge, Step Functions, Kinesis) as defense-in-depth, so this class of bug can't silently propagate again from an unrelated future mistake.

## Test plan
- [x] New regression tests reproducing the exact production line shape
- [x] `src/core/runtime` + `src/observability` suites pass (432 tests)
- [x] `tsc --noEmit` clean