### PR TITLE
chore(release): 1.1.0-beta.59

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.1.0-beta.59](https://github.com/ten24group/fw24/compare/v1.1.0-beta.57...v1.1.0-beta.59) (2026-07-26)
+
+
+### Bug Fixes
+
+* **api-gateway:** stable shared-root ownership for nested controllers (3 strategies) ([5d2560a](https://github.com/ten24group/fw24/commit/5d2560afbde67ce43847014e5a55841abd090db4)), closes [#263](https://github.com/ten24group/fw24/issues/263) [#289](https://github.com/ten24group/fw24/issues/289)
+
 ## [1.1.0-beta.57](https://github.com/ten24group/fw24/compare/v1.1.0-beta.55...v1.1.0-beta.57) (2026-07-24)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@ten24group/fw24",
-    "version": "1.1.0-beta.57",
+    "version": "1.1.0-beta.59",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@ten24group/fw24",
-            "version": "1.1.0-beta.57",
+            "version": "1.1.0-beta.59",
             "license": "MIT",
             "dependencies": {
                 "@aws-cdk/aws-amplify-alpha": "^2.202.0-alpha.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@ten24group/fw24",
     "description": "A modern, serverless, framework to launch software products quickly and scale seamlessly",
-    "version": "1.1.0-beta.57",
+    "version": "1.1.0-beta.59",
     "main": "./dist/package/fw24.js",
     "types": "./dist/package/fw24.d.ts",
     "repository": {


### PR DESCRIPTION
Automated release from `develop` (workflow [30212697177](https://github.com/ten24group/fw24/actions/runs/30212697177)).

- **Tag** `v1.1.0-beta.59` has been pushed.
- This branch contains the version bump (`1.1.0-beta.59`), changelog, and any `dist` updates.
- **Merge this PR** to update `develop` (nothing pushes to `develop` from Actions).

The merge commit message includes `ci/release-`, so merging does **not** re-trigger this workflow.
