### PR TITLE
fix(api): allow X-Correlation-Id, X-Caused-By and X-Actor in CORS preflight

### DIFF
--- a/src/constructs/__snapshots__/api.test.ts.snap
+++ b/src/constructs/__snapshots__/api.test.ts.snap
@@ -376,7 +376,7 @@ exports[`APIConstruct Snapshot Tests - CloudFormation Consistency should generat
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "testapiappapiDeployment9F8DA583e0e40954495aa88f904cfd3b3c1ec815": {
+    "testapiappapiDeployment9F8DA583e99ccb09d26f72184091487dc0ddd75b": {
       "DependsOn": [
         "testapiappapihealthGET85F76E98",
         "testapiappapihealthOPTIONSF3003BCB",
@@ -402,7 +402,7 @@ exports[`APIConstruct Snapshot Tests - CloudFormation Consistency should generat
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "testapiappapiDeployment9F8DA583e0e40954495aa88f904cfd3b3c1ec815",
+          "Ref": "testapiappapiDeployment9F8DA583e99ccb09d26f72184091487dc0ddd75b",
         },
         "RestApiId": {
           "Ref": "testapiappapiCF968FAD",
@@ -421,7 +421,7 @@ exports[`APIConstruct Snapshot Tests - CloudFormation Consistency should generat
             {
               "ResponseParameters": {
                 "method.response.header.Access-Control-Allow-Credentials": "'true'",
-                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,Authorization,X-Api-Key,X-Amz-Date,X-Amz-Content-Sha256,X-Amz-Security-Token,Access-Control-Allow-Credentials,Access-Control-Allow-Headers,Access-Control-Allow-Origin,Impersonating-User-Sub'",
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,Authorization,X-Api-Key,X-Amz-Date,X-Amz-Content-Sha256,X-Amz-Security-Token,Access-Control-Allow-Credentials,Access-Control-Allow-Headers,Access-Control-Allow-Origin,Impersonating-User-Sub,X-Correlation-Id,X-Caused-By,X-Actor'",
                 "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,POST,PUT,PATCH,DELETE'",
                 "method.response.header.Access-Control-Allow-Origin": "'*'",
               },
@@ -535,7 +535,7 @@ exports[`APIConstruct Snapshot Tests - CloudFormation Consistency should generat
             {
               "ResponseParameters": {
                 "method.response.header.Access-Control-Allow-Credentials": "'true'",
-                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,Authorization,X-Api-Key,X-Amz-Date,X-Amz-Content-Sha256,X-Amz-Security-Token,Access-Control-Allow-Credentials,Access-Control-Allow-Headers,Access-Control-Allow-Origin,Impersonating-User-Sub'",
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,Authorization,X-Api-Key,X-Amz-Date,X-Amz-Content-Sha256,X-Amz-Security-Token,Access-Control-Allow-Credentials,Access-Control-Allow-Headers,Access-Control-Allow-Origin,Impersonating-User-Sub,X-Correlation-Id,X-Caused-By,X-Actor'",
                 "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,POST,PUT,PATCH,DELETE'",
                 "method.response.header.Access-Control-Allow-Origin": "'*'",
               },
@@ -719,7 +719,7 @@ exports[`APIConstruct Snapshot Tests - CloudFormation Consistency should generat
       "Type": "AWS::IAM::Role",
       "UpdateReplacePolicy": "Retain",
     },
-    "testapiappapiDeployment9F8DA58398ad98577e03bfaa2ec9f8336ef60c71": {
+    "testapiappapiDeployment9F8DA58352e7705ec8a74e710877e8779314a449": {
       "DependsOn": [
         "testapiappapihealthGET85F76E98",
         "testapiappapihealthOPTIONSF3003BCB",
@@ -745,7 +745,7 @@ exports[`APIConstruct Snapshot Tests - CloudFormation Consistency should generat
       ],
       "Properties": {
         "DeploymentId": {
-          "Ref": "testapiappapiDeployment9F8DA58398ad98577e03bfaa2ec9f8336ef60c71",
+          "Ref": "testapiappapiDeployment9F8DA58352e7705ec8a74e710877e8779314a449",
         },
         "RestApiId": {
           "Ref": "testapiappapiCF968FAD",
@@ -764,7 +764,7 @@ exports[`APIConstruct Snapshot Tests - CloudFormation Consistency should generat
             {
               "ResponseParameters": {
                 "method.response.header.Access-Control-Allow-Credentials": "'true'",
-                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,Authorization,X-Api-Key,X-Amz-Date,X-Amz-Content-Sha256,X-Amz-Security-Token,Access-Control-Allow-Credentials,Access-Control-Allow-Headers,Access-Control-Allow-Origin,Impersonating-User-Sub'",
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,Authorization,X-Api-Key,X-Amz-Date,X-Amz-Content-Sha256,X-Amz-Security-Token,Access-Control-Allow-Credentials,Access-Control-Allow-Headers,Access-Control-Allow-Origin,Impersonating-User-Sub,X-Correlation-Id,X-Caused-By,X-Actor'",
                 "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,POST,PUT,PATCH,DELETE'",
                 "method.response.header.Access-Control-Allow-Origin": "'https://example.com'",
                 "method.response.header.Vary": "'Origin'",
@@ -889,7 +889,7 @@ exports[`APIConstruct Snapshot Tests - CloudFormation Consistency should generat
             {
               "ResponseParameters": {
                 "method.response.header.Access-Control-Allow-Credentials": "'true'",
-                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,Authorization,X-Api-Key,X-Amz-Date,X-Amz-Content-Sha256,X-Amz-Security-Token,Access-Control-Allow-Credentials,Access-Control-Allow-Headers,Access-Control-Allow-Origin,Impersonating-User-Sub'",
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,Authorization,X-Api-Key,X-Amz-Date,X-Amz-Content-Sha256,X-Amz-Security-Token,Access-Control-Allow-Credentials,Access-Control-Allow-Headers,Access-Control-Allow-Origin,Impersonating-User-Sub,X-Correlation-Id,X-Caused-By,X-Actor'",
                 "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,POST,PUT,PATCH,DELETE'",
                 "method.response.header.Access-Control-Allow-Origin": "'https://example.com'",
                 "method.response.header.Vary": "'Origin'",

--- a/src/constructs/api.test.ts
+++ b/src/constructs/api.test.ts
@@ -1226,16 +1226,27 @@ describe('APIConstruct', () => {
       });
 
       await apiConstruct.construct();
+      addMinimalMethod(apiConstruct.api);
 
-      // Verify framework configures these specific headers (api.ts:650-668):
-      // - Content-Type, Authorization, X-Api-Key
-      // - X-Amz-Date, X-Amz-Content-Sha256, X-Amz-Security-Token
-      // - Access-Control-Allow-Credentials, Access-Control-Allow-Headers, Access-Control-Allow-Origin
-      // - Impersonating-User-Sub (custom header)
-
-      // We can't directly test internal getCorsPreflightOptions() but we verify API was created with CORS
-      expect(apiConstruct.api).toBeDefined();
-      expect((apiConstruct as any).apiConstructConfig.cors).toBe(true);
+      // The preflight OPTIONS mock must allow every header the framework's own clients send —
+      // notably the tracing/identity headers (x-correlation-id, x-caused-by, x-actor) the runtime
+      // consumes. A header missing from this list fails the browser preflight for any request
+      // carrying it, so the whole call dies as a CORS error before reaching the backend.
+      const template = Template.fromStack(stack);
+      template.hasResourceProperties('AWS::ApiGateway::Method', {
+        HttpMethod: 'OPTIONS',
+        Integration: {
+          IntegrationResponses: [
+            Match.objectLike({
+              ResponseParameters: Match.objectLike({
+                'method.response.header.Access-Control-Allow-Headers': Match.stringLikeRegexp(
+                  'Impersonating-User-Sub,X-Correlation-Id,X-Caused-By,X-Actor'
+                ),
+              }),
+            }),
+          ],
+        },
+      });
     });
 
     it('should enable CORS credentials', async () => {

--- a/src/constructs/api.ts
+++ b/src/constructs/api.ts
@@ -660,6 +660,14 @@ export class APIConstruct implements FW24Construct {
                 "Access-Control-Allow-Headers",
                 "Access-Control-Allow-Origin",
                 "Impersonating-User-Sub",
+                // Tracing/identity headers the framework itself consumes: x-correlation-id and
+                // x-caused-by feed correlation propagation, x-actor carries the end-user identity on
+                // SigV4-signed calls (see api-gateway-controller). Browsers preflight any request
+                // carrying them, so they must be allowed here or every instrumented cross-origin
+                // call fails CORS before reaching the backend.
+                "X-Correlation-Id",
+                "X-Caused-By",
+                "X-Actor",
             ],
             allowMethods: [ "OPTIONS", "GET", "POST", "PUT", "PATCH", "DELETE" ],
             allowCredentials: true,


### PR DESCRIPTION
## Problem

The API Gateway CORS preflight uses a hardcoded `allowHeaders` list in `getCorsPreflightOptions()` that omits three headers the framework's own runtime consumes:

- `x-correlation-id` / `x-caused-by` → correlation propagation (`src/core/runtime/correlation-propagation`)
- `x-actor` → client-supplied actor identity for SigV4-signed calls (`api-gateway-controller`)

Browsers preflight any cross-origin request carrying a non-safelisted header, so a client instrumented to send these (e.g. request tracing) fails the preflight and the call dies as a CORS error before ever reaching the backend.

## Change

- Add `X-Correlation-Id`, `X-Caused-By`, `X-Actor` to the CORS preflight `allowHeaders` (`src/constructs/api.ts`).
- Strengthen the previously assertion-free CORS-headers test to verify the synthesized `OPTIONS` mock actually carries the full header list; update the 2 affected template snapshots (diff is the header string only).

## Testing

- `npx jest src/constructs/api.test.ts` — 70/70 pass.
- `tsc --noEmit` clean.
- Remaining full-suite failures are pre-existing on `develop` (integration suites requiring local DynamoDB/Meilisearch services; unrelated stale snapshots in `queue`/`lambda-function`).